### PR TITLE
Fix homepage lead capture + SEO foundation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,10 @@ jobs:
           # Brand assets
           cp brand/* dist/brand/ 2>/dev/null || true
 
+          # SEO
+          cp robots.txt dist/robots.txt
+          cp sitemap.xml dist/sitemap.xml
+
           # Custom domain
           echo "bahkobyra.se" > dist/CNAME
 

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -14,7 +14,7 @@
 <meta property="og:url" content="https://www.bahkobyra.se/">
 <meta property="og:title" content="Bahko Byrå | Hemsidor, SEO & Google Ads för Svenska Kliniker">
 <meta property="og:description" content="Bahko Byrå hjälper svenska kliniker att synas på Google, få fler bokningar och växa online. Professionella hemsidor, Google Ads och SEO.">
-<meta property="og:image" content="https://www.bahkobyra.se/favicon.png">
+<meta property="og:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
 <meta property="og:locale" content="sv_SE">
 <meta property="og:site_name" content="Bahko Byrå">
 
@@ -22,7 +22,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Bahko Byrå | Hemsidor, SEO & Google Ads för Svenska Kliniker">
 <meta name="twitter:description" content="Vi hjälper svenska kliniker att synas på Google, få fler bokningar och växa online.">
-<meta name="twitter:image" content="https://www.bahkobyra.se/favicon.png">
+<meta name="twitter:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -32,19 +32,23 @@
 <link rel="apple-touch-icon" href="favicon.png">
 <link rel="stylesheet" href="css/style.css">
 
-<!-- Schema: Organization + LocalBusiness -->
+<!-- Schema: Organization + LocalBusiness. TODO: lägg till "telephone" och fyll "sameAs" med era sociala profiler (Instagram/Facebook/LinkedIn). -->
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": ["Organization", "LocalBusiness"],
   "name": "Bahko Byrå",
   "url": "https://www.bahkobyra.se",
-  "logo": "https://www.bahkobyra.se/favicon.png",
+  "logo": "https://www.bahkobyra.se/brand/BahkoStudio-removebg-preview.png",
+  "image": "https://www.bahkobyra.se/brand/Bahkostudio.jpg",
+  "email": "mathias@bahkobyra.se",
   "description": "Digital byrå specialiserad på hemsidor, SEO och Google Ads för svenska kliniker och skönhetsföretag.",
   "slogan": "Synlighet som säljer.",
+  "priceRange": "$$",
   "areaServed": "SE",
   "inLanguage": "sv",
-  "contactPoint": { "@type": "ContactPoint", "contactType": "sales", "areaServed": "SE", "availableLanguage": "Swedish" },
+  "knowsAbout": ["Lokal SEO", "Google Ads", "Webbdesign", "Google Företagsprofil", "Sociala medier-annonsering"],
+  "contactPoint": { "@type": "ContactPoint", "contactType": "sales", "email": "mathias@bahkobyra.se", "areaServed": "SE", "availableLanguage": "Swedish" },
   "sameAs": [],
   "offers": [
     { "@type": "Offer", "name": "Hemsida", "description": "Professionell hemsida för kliniker" },
@@ -268,13 +272,14 @@
       <span class="line"><span><em>kostnadsfria</em> samtal.</span></span>
     </h2>
     <p class="lede" data-reveal style="margin:1.2rem auto 0">Fyll i nedan så hör vi av oss inom 24 timmar för att boka ett kort samtal.</p>
-    <form class="cform" id="cform" data-reveal>
+    <form class="cform" id="cform" action="https://formspree.io/f/mgonrnep" method="POST" data-reveal>
       <div class="crow">
-        <div class="field"><label>Namn</label><input type="text" placeholder="Anna Svensson" required></div>
-        <div class="field"><label>Telefon</label><input type="tel" placeholder="070 000 00 00"></div>
+        <div class="field"><label for="cf-namn">Namn</label><input type="text" id="cf-namn" name="namn" placeholder="Anna Svensson" required autocomplete="name"></div>
+        <div class="field"><label for="cf-tel">Telefon</label><input type="tel" id="cf-tel" name="telefon" placeholder="070 000 00 00" autocomplete="tel"></div>
       </div>
-      <div class="field"><label>E-post</label><input type="email" placeholder="anna@dinverksamhet.se" required></div>
-      <div class="field"><label>Hur kan vi hjälpa dig?</label><textarea placeholder="Berätta kort om din verksamhet och vad du vill uppnå..."></textarea></div>
+      <div class="field"><label for="cf-epost">E-post</label><input type="email" id="cf-epost" name="email" placeholder="anna@dinverksamhet.se" required autocomplete="email"></div>
+      <div class="field"><label for="cf-msg">Hur kan vi hjälpa dig?</label><textarea id="cf-msg" name="meddelande" placeholder="Berätta kort om din verksamhet och vad du vill uppnå..."></textarea></div>
+      <input type="hidden" name="_subject" value="Ny kontaktförfrågan – startsidan (bahkobyra.se)">
       <button class="btn btn-gold magnetic" data-magnetic=".2" type="submit"><span>Skicka Förfrågan</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></button>
     </form>
     <div class="cok" id="cok">

--- a/bahkobyra/js/main.js
+++ b/bahkobyra/js/main.js
@@ -343,10 +343,23 @@
   function initForm() {
     const form = $('#cform'); const ok = $('#cok');
     if (!form) return;
-    form.addEventListener('submit', (e) => {
+    const btn = $('button[type="submit"]', form);
+    form.addEventListener('submit', async (e) => {
       e.preventDefault();
-      form.style.display = 'none';
-      if (ok) ok.classList.add('show');
+      if (btn) btn.disabled = true;
+      try {
+        const res = await fetch(form.action, {
+          method: 'POST',
+          body: new FormData(form),
+          headers: { 'Accept': 'application/json' }
+        });
+        if (!res.ok) throw new Error('bad response');
+        form.style.display = 'none';
+        if (ok) ok.classList.add('show');
+      } catch {
+        if (btn) btn.disabled = false;
+        alert('Något gick fel. Försök igen eller mejla oss direkt på mathias@bahkobyra.se');
+      }
     });
   }
 

--- a/kliniker/crm.html
+++ b/kliniker/crm.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Bahko Byrå — CRM</title>
+<meta name="robots" content="noindex, nofollow">
 <link href="https://fonts.googleapis.com/css2?family=Syne:wght@600;700;800&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /kliniker/crm.html
+
+Sitemap: https://www.bahkobyra.se/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.bahkobyra.se/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.bahkobyra.se/kliniker/gratis-granskning.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Vad
Första optimerings-PR:en för bahkobyra.se. Enbart additiva fixar — rör inte designen eller animationerna.

## Kritiskt: leadformuläret fångade inget
Startsidans kontaktformulär (`#cform`) postade ingenstans — `main.js` dolde bara formuläret och visade Tack!, så varje förfrågan försvann. Nu postar det till Formspree (samma endpoint som er analyssida) → mathias@bahkobyra.se. La även till `name`/`id`/`for`/`autocomplete` på fälten (tillgänglighet + krävs för Formspree).

## SEO och teknik
- **robots.txt + sitemap.xml** (nya) + inkopplade i `deploy.yml`
- **LocalBusiness-schema** utökat: `email`, `image`, `priceRange`, `knowsAbout`
- **OG/Twitter-bild**: riktig brand-bild istället för 74 kb favicon
- **noindex** på `kliniker/crm.html` — internt CRM som ligger publikt på bahkobyra.se

## Att fylla i senare
- `telephone` + `sameAs` (sociala profiler) i schemat
- Dedikerad 1200x630 delningsbild

## Test efter merge
Skicka ett testmeddelande via startsidans formulär och bekräfta att det landar i mathias@bahkobyra.se.

🤖 Generated with [Claude Code](https://claude.com/claude-code)