### PR TITLE
Add free guide + video lead magnet page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
           cp kliniker/elara-klinik-demo-v2.html dist/kliniker/elara-klinik-demo-v2.html
           cp kliniker/crm.html dist/kliniker/crm.html
           cp kliniker/gratis-granskning.html dist/kliniker/gratis-granskning.html
+          cp kliniker/gratis-guide.html dist/kliniker/gratis-guide.html
 
           # Brand assets
           cp brand/* dist/brand/ 2>/dev/null || true

--- a/kliniker/gratis-guide-video-manus.md
+++ b/kliniker/gratis-guide-video-manus.md
@@ -1,0 +1,50 @@
+# Videomanus — "3 sätt att ranka högre på Google"
+
+Videon för leadmagneten på `kliniker/gratis-guide.html`. Samma 3 tips som textguiden, men som film du spelar in själv.
+
+**Längd:** ~3–4 min · **Ton:** lugn, hjälpsam, som att du förklarar för en bekant (inte säljig).
+**Setup:** prata rakt in i kameran (mobil i ögonhöjd, ljus framför dig, tyst rum).
+**När den är klar:** ladda upp olistad på YouTube eller Loom → klistra in embed-koden i `gratis-guide.html` (sök efter `BYT UT` i koden).
+
+---
+
+### 0:00 — Hook
+> "Om du driver en klinik och inte hamnar bland de tre översta när folk googlar din behandling i din stad — då tappar du patienter varje vecka, utan att ens veta om det. Jag ska ge dig tre konkreta saker du kan fixa själv den här veckan för att klättra på Google. Inga tekniska kunskaper behövs. Vi kör."
+
+*[Säg det med energi men lugnt. Le. Första meningen avgör om de stannar.]*
+
+### 0:20 — Varför det spelar roll
+> "När någon söker, säg 'hudvårdsklinik Västerås', visar Google en karta med tre företag högst upp. De tre får nästan alla samtal. Är du inte där, finns du knappt — även om du är bäst i stan. Och det fina: det går att påverka."
+
+*[VISA: en Google-sökning på "[behandling] [ort]" så map-packet syns.]*
+
+### 0:40 — Tips 1: Google Företagsprofil
+> "Tips ett: gör din Google Företagsprofil helt komplett. Det är det som visas i kartan och den största faktorn för var du hamnar. De flesta fyller i den till hälften. Gå in på google.com/business. Välj exakt rätt huvudkategori, fyll i allt — tjänster, öppettider, bokningslänk — och ladda upp minst tio riktiga foton. Bara det flyttar många uppåt inom ett par veckor."
+
+*[VISA: skärminspelning i en företagsprofil, peka på kategori-fältet.]*
+
+### 1:40 — Tips 2: Recensioner
+> "Tips två: sätt recensioner i system. Kliniken med flest och färskast recensioner vinner nästan alltid — både Googles förtroende och patientens. Skapa din recensionslänk, korta ner den, och be varje nöjd patient samma dag via SMS eller en QR-kod i receptionen. Svara på alla recensioner. Mål: en till två nya i veckan. För alltid."
+
+*[VISA: ett exempel-SMS med recensionslänk eller en QR-kod.]*
+
+### 2:40 — Tips 3: Ort + NAP
+> "Tips tre: gör glasklart för Google vad du gör och var. Sätt din ort i rubriken på hemsidan. Och se till att namn, adress och telefonnummer ser exakt likadana ut överallt — sajt, Google, Hitta, Eniro, Facebook. Minsta skillnad förvirrar Google. Lägg också upp kliniken på Bing och Apple Maps med samma uppgifter."
+
+*[VISA: din hemsidas rubrik + ett par kataloger sida vid sida.]*
+
+### 3:30 — Avslut + CTA
+> "Gör de här tre sakerna så ser du oftast rörelse inom fyra till åtta veckor. Och kom ihåg — skillnaden mellan plats ett och plats fem är ofta tre till fem gånger fler samtal. Vill du veta exakt var DU ligger idag? Vi gör en gratis synlighetskoll — länken finns precis här nedanför. Lycka till, och börja med tips ett redan idag."
+
+*[Avsluta varmt, peka neråt. Lägg en textruta i klippet: "Gratis synlighetskoll → bahkobyra.se".]*
+
+---
+
+## Inspelnings-checklista
+- [ ] Mobil i ögonhöjd, stativ/stötta
+- [ ] Ljus framför dig (fönster funkar)
+- [ ] Tyst rum, gärna extern mikrofon
+- [ ] Horisontellt (16:9) för sidan + en vertikal (9:16) tagning för Reels/TikTok
+- [ ] Skärminspelningar för [VISA]-klippen
+- [ ] CTA-textruta sista 20 sekunderna
+- [ ] Ladda upp olistad (YouTube/Loom) → klistra in embed i `gratis-guide.html`

--- a/kliniker/gratis-guide.html
+++ b/kliniker/gratis-guide.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Gratis guide + video: 3 sätt att ranka högre på Google | Bahko Byrå</title>
+<meta name="description" content="Få Bahko Byrås gratisguide + en kort video som visar exakt hur din klinik rankar högre på Google och Google Maps — utan att betala för annonser. Direkt, gratis.">
+<meta name="robots" content="index, follow">
+<meta name="theme-color" content="#0c0a09">
+<link rel="canonical" href="https://www.bahkobyra.se/kliniker/gratis-guide.html">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.bahkobyra.se/kliniker/gratis-guide.html">
+<meta property="og:title" content="Gratis guide + video: 3 sätt att ranka högre på Google">
+<meta property="og:description" content="Få guiden + en kort video som visar exakt hur du tar din klinik till topp 3 på Google. Gratis.">
+<meta property="og:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
+<meta property="og:locale" content="sv_SE">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" type="image/png" href="/bahkobyra/favicon.png">
+
+<style>
+  *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+  :root{
+    --gold:#c9a96e; --gold-lt:#e0c48a; --bg:#0c0a09; --bg2:#15110f;
+    --card:#1b1613; --text:#f0ece4; --muted:#a59f95; --line:rgba(240,236,228,.12);
+  }
+  html{scroll-behavior:smooth}
+  body{background:var(--bg);color:var(--text);font-family:'Outfit',-apple-system,BlinkMacSystemFont,sans-serif;line-height:1.65;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:0 24px}
+  h1,h2,h3{font-family:'Cormorant Garamond',Georgia,serif;font-weight:600;line-height:1.12;letter-spacing:-.01em}
+  h1{font-size:clamp(34px,6vw,58px)}
+  h2{font-size:clamp(28px,4vw,40px)}
+  h3{font-size:24px}
+  p{color:var(--muted);font-size:17px}
+  a{color:inherit;text-decoration:none}
+  em{color:var(--gold);font-style:italic}
+  .gold{color:var(--gold)}
+  .eyebrow{display:inline-block;font-family:'Outfit',sans-serif;font-size:12px;font-weight:600;letter-spacing:.22em;text-transform:uppercase;color:var(--gold);margin-bottom:18px}
+  .btn{display:inline-flex;align-items:center;justify-content:center;gap:10px;font-family:'Outfit',sans-serif;font-weight:600;font-size:16px;padding:16px 30px;border-radius:2px;border:0;cursor:pointer;transition:.2s;background:var(--gold);color:#1a140e}
+  .btn:hover{background:var(--gold-lt);transform:translateY(-2px)}
+  .btn svg{width:18px;height:18px;fill:none;stroke:currentColor;stroke-width:2}
+
+  /* TOPBAR */
+  .topbar{border-bottom:1px solid var(--line)}
+  .topbar .wrap{display:flex;align-items:center;justify-content:space-between;height:68px}
+  .logo{font-family:'Cormorant Garamond',serif;font-size:24px;font-weight:700;letter-spacing:.01em}
+  .logo em{font-style:italic}
+  .topbar a.back{font-size:14px;color:var(--muted)}
+  .topbar a.back:hover{color:var(--text)}
+
+  /* HERO */
+  .hero{padding:72px 0 40px;text-align:center;position:relative;overflow:hidden}
+  .hero::before{content:"";position:absolute;top:-30%;left:50%;transform:translateX(-50%);width:600px;height:600px;background:radial-gradient(circle,rgba(201,169,110,.16),transparent 65%);pointer-events:none}
+  .hero .inner{position:relative;z-index:1;max-width:760px;margin:0 auto}
+  .hero h1{margin-bottom:22px}
+  .hero .lede{font-size:20px;max-width:620px;margin:0 auto 14px}
+  .vid-hint{display:inline-flex;align-items:center;gap:10px;color:var(--gold);font-size:15px;margin-top:8px}
+  .vid-hint .pl{width:30px;height:30px;border-radius:50%;background:var(--gold);color:#1a140e;display:grid;place-items:center}
+
+  /* OPT-IN CARD */
+  .optin{max-width:480px;margin:34px auto 0;background:var(--card);border:1px solid var(--line);border-radius:6px;padding:30px;text-align:left}
+  .optin h3{font-family:'Outfit',sans-serif;font-size:18px;font-weight:600;text-align:center;margin-bottom:6px}
+  .optin .sub{font-size:14px;text-align:center;margin-bottom:20px}
+  .field{margin-bottom:14px}
+  .field label{display:block;font-size:13px;font-weight:500;color:var(--text);margin-bottom:6px}
+  .field input{width:100%;padding:14px 15px;background:var(--bg);border:1px solid var(--line);border-radius:3px;color:var(--text);font-size:15px;font-family:inherit;transition:.15s}
+  .field input::placeholder{color:#6b665e}
+  .field input:focus{outline:0;border-color:var(--gold);box-shadow:0 0 0 3px rgba(201,169,110,.15)}
+  .optin .btn{width:100%;margin-top:6px}
+  .optin .fine{font-size:12px;color:#6b665e;text-align:center;margin-top:14px}
+
+  /* TEASER BULLETS */
+  .teasers{max-width:560px;margin:40px auto 0;text-align:left;display:grid;gap:14px}
+  .teaser{display:flex;gap:14px;align-items:flex-start}
+  .teaser .n{flex:none;width:30px;height:30px;border-radius:50%;border:1px solid var(--gold);color:var(--gold);display:grid;place-items:center;font-family:'Cormorant Garamond',serif;font-size:17px;font-weight:700}
+  .teaser b{color:var(--text);font-weight:500}
+
+  /* DIVIDER */
+  .div{height:1px;background:var(--line);max-width:920px;margin:64px auto}
+
+  /* REVEALED GUIDE */
+  #guide-content{display:none;padding:20px 0 40px}
+  #guide-content.show{display:block;animation:fade .6s ease}
+  @keyframes fade{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+  .reveal-head{text-align:center;max-width:680px;margin:0 auto 36px}
+  .reveal-head .badge{display:inline-block;background:rgba(201,169,110,.14);color:var(--gold);border:1px solid var(--line);border-radius:999px;padding:6px 16px;font-size:13px;font-weight:500;margin-bottom:18px}
+
+  /* VIDEO */
+  .video-wrap{max-width:820px;margin:0 auto 56px}
+  .video-frame{position:relative;width:100%;aspect-ratio:16/9;background:var(--bg2);border:1px solid var(--line);border-radius:8px;overflow:hidden}
+  .video-frame iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
+  .video-ph{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;background:radial-gradient(circle at 50% 40%,rgba(201,169,110,.12),transparent 60%)}
+  .video-ph .play{width:74px;height:74px;border-radius:50%;background:var(--gold);color:#1a140e;display:grid;place-items:center;font-size:28px}
+  .video-ph span{color:var(--muted);font-size:14px}
+
+  /* TIPS */
+  .tip{max-width:760px;margin:0 auto 40px;padding-bottom:40px;border-bottom:1px solid var(--line)}
+  .tip:last-of-type{border-bottom:0}
+  .tip-n{font-family:'Cormorant Garamond',serif;font-size:15px;letter-spacing:.2em;text-transform:uppercase;color:var(--gold);margin-bottom:10px}
+  .tip h3{margin-bottom:14px}
+  .tip p{margin-bottom:16px}
+  .tip ul{list-style:none;display:grid;gap:11px}
+  .tip li{display:flex;gap:12px;align-items:flex-start;color:var(--text);font-size:16px}
+  .tip li::before{content:"✓";color:var(--gold);font-weight:700;flex:none}
+  .tip .win{margin-top:16px;font-size:15px;color:var(--gold);font-style:italic;font-family:'Cormorant Garamond',serif;font-size:19px}
+
+  /* CTA */
+  .endcta{text-align:center;max-width:620px;margin:10px auto 0;padding:44px 30px;background:var(--card);border:1px solid var(--line);border-radius:8px}
+  .endcta h2{margin-bottom:14px}
+  .endcta p{margin-bottom:24px}
+
+  /* FOOTER */
+  footer{border-top:1px solid var(--line);margin-top:72px;padding:30px 0}
+  footer .wrap{display:flex;justify-content:space-between;flex-wrap:wrap;gap:10px;font-size:14px;color:var(--muted)}
+  footer a:hover{color:var(--gold)}
+
+  @media(max-width:640px){.hero{padding:48px 0 30px}.optin{padding:24px}}
+</style>
+</head>
+<body>
+
+<!-- TOPBAR -->
+<div class="topbar">
+  <div class="wrap">
+    <a href="/" class="logo">Bahko <em>Byrå</em></a>
+    <a href="/" class="back">← Till startsidan</a>
+  </div>
+</div>
+
+<!-- HERO + OPT-IN -->
+<section class="hero">
+  <div class="inner wrap">
+    <span class="eyebrow">Gratis guide + video</span>
+    <h1>3 sätt att ranka <em>högre</em> på Google — utan att betala för annonser</h1>
+    <p class="lede">Få vår gratisguide plus en kort video som visar <strong style="color:var(--text)">exakt</strong> hur du tar din klinik till topp 3 på Google och Google Maps. Inga tekniska kunskaper behövs.</p>
+    <div class="vid-hint"><span class="pl">▶</span> Guide i text + ~4 min video</div>
+
+    <!-- OPT-IN: capture via Formspree, reveal guide+video on success -->
+    <div class="optin" id="optin">
+      <form id="guide-form" action="https://formspree.io/f/mgonrnep" method="POST">
+        <h3>Få guiden + videon direkt 👇</h3>
+        <p class="sub">Skriv in din e-post så låser vi upp guiden och videon på direkten.</p>
+        <div class="field">
+          <label for="g-namn">Förnamn</label>
+          <input type="text" id="g-namn" name="namn" placeholder="Ditt förnamn" autocomplete="given-name">
+        </div>
+        <div class="field">
+          <label for="g-epost">E-post</label>
+          <input type="email" id="g-epost" name="email" placeholder="du@dinklinik.se" required autocomplete="email">
+        </div>
+        <input type="hidden" name="_subject" value="Ny guide-nedladdning – lead magnet (gratis-guide)">
+        <button class="btn" type="submit" id="g-btn"><span>Lås upp guiden + videon</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></button>
+        <p class="fine">Ingen bindning. Vi spammar inte. Avregistrera när du vill.</p>
+      </form>
+    </div>
+
+    <!-- visible teasers (bygger lust + SEO) -->
+    <div class="teasers">
+      <div class="teaser"><span class="n">1</span><div><b>Gör din Google Företagsprofil komplett</b> — den största rankingfaktorn de flesta missar till hälften.</div></div>
+      <div class="teaser"><span class="n">2</span><div><b>Sätt recensioner i system</b> — så hamnar du över konkurrenten patienterna annars väljer.</div></div>
+      <div class="teaser"><span class="n">3</span><div><b>Lokala signaler &amp; NAP</b> — gör det glasklart för Google var och vad du är.</div></div>
+    </div>
+  </div>
+</section>
+
+<div class="div"></div>
+
+<!-- ============ REVEALED AFTER OPT-IN ============ -->
+<section id="guide-content">
+  <div class="wrap">
+    <div class="reveal-head">
+      <span class="badge">✓ Upplåst — här är din guide + video</span>
+      <h2>Så rankar du <em>högre</em> på Google</h2>
+      <p>Titta på videon först, läs sedan stegen. Börja med tips 1 redan idag.</p>
+    </div>
+
+    <!-- VIDEO -->
+    <div class="video-wrap">
+      <div class="video-frame">
+        <!-- ====================================================================
+             BYT UT placeholdern nedan mot din inspelade video.
+             YouTube (olistad):  <iframe src="https://www.youtube.com/embed/DITT_ID" title="..." allowfullscreen></iframe>
+             Loom:               <iframe src="https://www.loom.com/embed/DITT_ID" allowfullscreen></iframe>
+             Manus att spela in finns i: kliniker/gratis-guide-video-manus.md (i repot)
+        ===================================================================== -->
+        <div class="video-ph">
+          <span class="play">▶</span>
+          <span>Din video läggs här (se kommentar i koden)</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- TIP 1 -->
+    <article class="tip">
+      <div class="tip-n">Tips 1</div>
+      <h3>Gör din Google Företagsprofil komplett — och välj rätt kategori</h3>
+      <p>Profilen som visas i kartan är den enskilt största faktorn för var du hamnar lokalt. De flesta fyller i den till hälften och undrar sedan varför de ligger lågt.</p>
+      <ul>
+        <li>Logga in via <strong style="color:var(--text)">google.com/business</strong> (eller sök ditt företagsnamn → "Hantera").</li>
+        <li>Sätt <strong style="color:var(--text)">exakt rätt huvudkategori</strong> (t.ex. "Hudvårdsklinik", inte bara "Klinik"). Lägg till 1–2 relevanta till — sedan stopp.</li>
+        <li>Fyll i <strong style="color:var(--text)">allt</strong>: öppettider, tjänster med beskrivningar, attribut, bokningslänk och en beskrivning med din ort i.</li>
+        <li>Ladda upp minst 10 riktiga foton (lokal, team, behandlingar, före/efter).</li>
+      </ul>
+      <p class="win">Snabb vinst: en halvtom profil som blir 100 % ifylld rör sig ofta uppåt inom ett par veckor.</p>
+    </article>
+
+    <!-- TIP 2 -->
+    <article class="tip">
+      <div class="tip-n">Tips 2</div>
+      <h3>Sätt recensioner i system</h3>
+      <p>Företaget med flest och färskast recensioner vinner nästan alltid — både Googles förtroende (ranking) och patientens (klicket). De flesta ber aldrig, eller för sällan.</p>
+      <ul>
+        <li>Skapa din recensionslänk i profilen och korta ner den så den är lätt att dela.</li>
+        <li>Be <strong style="color:var(--text)">varje</strong> nöjd kund samma dag — via SMS eller en QR-kod i receptionen. Ett klick för dem.</li>
+        <li>Svara på alla recensioner, även de sura. Lugnt och professionellt.</li>
+        <li>Mål: 1–2 nya recensioner i veckan, för alltid.</li>
+      </ul>
+      <p class="win">Snabb vinst: börja idag med dina tre senaste nöjda kunder.</p>
+    </article>
+
+    <!-- TIP 3 -->
+    <article class="tip">
+      <div class="tip-n">Tips 3</div>
+      <h3>Få ort + tjänst på rätt ställen (lokala signaler &amp; NAP)</h3>
+      <p>Google måste förstå <em>vad</em> du gör och <em>var</em> du finns. Hjälp den genom att vara tydlig och konsekvent — på sajten och ute på nätet.</p>
+      <ul>
+        <li>Sätt din ort i sidtiteln och i huvudrubriken (H1): t.ex. "Hudvårdsklinik i Västerås – [Namn]".</li>
+        <li><strong style="color:var(--text)">NAP</strong> (namn, adress, telefon) ska se exakt likadana ut överallt: sajt, Google, Hitta, Eniro, Facebook.</li>
+        <li>Lägg upp företaget med samma uppgifter på Bing Places, Apple Business Connect och de svenska katalogerna.</li>
+        <li>Bädda in en Google-karta på din kontaktsida.</li>
+      </ul>
+      <p class="win">Snabb vinst: rätta NAP så den är identisk på de fem viktigaste ställena — gjort på en timme.</p>
+    </article>
+
+    <!-- END CTA -->
+    <div class="endcta">
+      <h2>Vill du veta exakt var <em>du</em> ligger?</h2>
+      <p>Vi gör en gratis synlighetskoll: din position på kartan idag, vilka som ligger över dig och de tre sakerna vi skulle fixa först för just din klinik.</p>
+      <a href="/#kontakt" class="btn"><span>Boka gratis samtal</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <span>© 2026 Bahko Byrå · Synlighet som säljer.</span>
+    <span><a href="mailto:mathias@bahkobyra.se">mathias@bahkobyra.se</a></span>
+  </div>
+</footer>
+
+<script>
+  const form = document.getElementById('guide-form');
+  const optin = document.getElementById('optin');
+  const guide = document.getElementById('guide-content');
+  const btn = document.getElementById('g-btn');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    btn.disabled = true;
+    btn.querySelector('span').textContent = 'Låser upp...';
+    try {
+      const res = await fetch(form.action, {
+        method: 'POST',
+        body: new FormData(form),
+        headers: { 'Accept': 'application/json' }
+      });
+      if (!res.ok) throw new Error('bad response');
+      optin.style.display = 'none';
+      guide.classList.add('show');
+      guide.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } catch {
+      btn.disabled = false;
+      btn.querySelector('span').textContent = 'Lås upp guiden + videon';
+      alert('Något gick fel. Försök igen eller mejla oss på mathias@bahkobyra.se');
+    }
+  });
+</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://www.bahkobyra.se/kliniker/gratis-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Vad
Lägger till en leadmagnet: en sida där besökaren registrerar sig och **direkt får guiden + en video** som visar exakt hur man rankar högre på Google.

## Sidan: `kliniker/gratis-guide.html`
- Branded opt-in (guld/svart, Cormorant + Outfit) som matchar resten av sajten
- E-post fångas via Formspree (samma endpoint, `_subject` "Ny guide-nedladdning" för filtrering)
- Vid registrering: formuläret göms och guiden + videon låses upp på samma sida (ingen e-postberoende leverans)
- 3 konkreta tips (Google Företagsprofil, recensioner, NAP/lokala signaler)
- Videoruta som platshållare — byt mot din YouTube/Loom-embed (sök `BYT UT` i koden)

## Video
- Inspelningsmanus: `kliniker/gratis-guide-video-manus.md` (samma 3 tips, ~3–4 min, hook + CTA + checklista)

## Infra
- Inkopplad i `deploy.yml` (kopieras till dist/kliniker/)
- Tillagd i `sitemap.xml`

## Att göra för dig
1. Spela in videon (manuset finns i repot) → klistra in embed i `gratis-guide.html`
2. (Valfritt) länka till sidan från startsidan/outreach så folk hittar den

## Test efter merge
Registrera dig på sidan och bekräfta att (a) guiden + videorutan visas direkt, och (b) mejlet landar hos mathias@bahkobyra.se.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
