### PR TITLE
Rebrand Élara demo to Bahko gold theme

### DIFF
--- a/kliniker/elara-klinik-demo-v2.html
+++ b/kliniker/elara-klinik-demo-v2.html
@@ -6,21 +6,21 @@
 <title>ÉLARA KLINIK — Naturlig Skönhet, Förhöjd</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root{
-  --bg:#06061A;
-  --bg-warm:#0B0B28;
-  --cream:#F0EDFF;
-  --gold:#9B5CF6;
-  --gold-light:#C4B5FD;
-  --rose:#A78BFA;
-  --text-primary:#F0EDFF;
-  --text-secondary:rgba(240,237,255,.5);
-  --text-muted:rgba(240,237,255,.28);
+  --bg:#0c0a09;
+  --bg-warm:#15110f;
+  --cream:#f0ece4;
+  --gold:#c9a96e;
+  --gold-light:#e0c48a;
+  --rose:#d8bd8f;
+  --text-primary:#f0ece4;
+  --text-secondary:rgba(240,236,228,.5);
+  --text-muted:rgba(240,236,228,.28);
   --font-display:'Cormorant Garamond',serif;
-  --font-body:'Inter',sans-serif;
+  --font-body:'Outfit',sans-serif;
 }
 html{background:var(--bg)}
 body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body);overflow-x:hidden;-webkit-font-smoothing:antialiased}
@@ -29,13 +29,13 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 #loader{position:fixed;inset:0;z-index:9999;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center;transition:opacity .6s ease,visibility .6s ease}
 #loader.hidden{opacity:0;visibility:hidden;pointer-events:none}
 .loader-brand{font-family:var(--font-display);font-size:clamp(2rem,5vw,3.5rem);font-weight:300;letter-spacing:.3em;color:var(--cream);margin-bottom:3rem;text-transform:uppercase}
-#loader-bar-wrap{width:min(300px,60vw);height:1px;background:rgba(139,92,246,.2);border-radius:1px;overflow:hidden}
+#loader-bar-wrap{width:min(300px,60vw);height:1px;background:rgba(201,169,110,.2);border-radius:1px;overflow:hidden}
 #loader-bar{width:0%;height:100%;background:linear-gradient(90deg,var(--gold),var(--gold-light));transition:width .3s ease}
 #loader-percent{font-family:var(--font-body);font-size:.75rem;letter-spacing:.2em;color:var(--text-muted);margin-top:1.2rem;font-weight:300}
 
 /* ===== HEADER ===== */
 .site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1.8rem,env(safe-area-inset-top)) 3vw 1.8rem;display:flex;justify-content:space-between;align-items:center}
-.site-header.scrolled{background:rgba(6,6,26,.88);backdrop-filter:blur(20px);border-bottom:1px solid rgba(139,92,246,.1)}
+.site-header.scrolled{background:rgba(12,10,9,.88);backdrop-filter:blur(20px);border-bottom:1px solid rgba(201,169,110,.1)}
 .header-logo{font-family:var(--font-display);font-size:1.1rem;font-weight:400;letter-spacing:.35em;color:var(--cream);text-transform:uppercase;text-decoration:none}
 .header-nav{display:flex;gap:2.5rem;align-items:center}
 .header-nav a{font-family:var(--font-body);font-size:.7rem;font-weight:300;letter-spacing:.2em;color:var(--cream);text-decoration:none;text-transform:uppercase;opacity:.7;transition:opacity .3s}
@@ -47,14 +47,14 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .hamburger.open span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger.open span:nth-child(2){opacity:0}
 .hamburger.open span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
-.mobile-nav{position:fixed;inset:0;background:rgba(6,6,26,.97);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.5rem;opacity:0;visibility:hidden;transition:all .4s ease}
+.mobile-nav{position:fixed;inset:0;background:rgba(12,10,9,.97);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.5rem;opacity:0;visibility:hidden;transition:all .4s ease}
 .mobile-nav.open{opacity:1;visibility:visible}
 .mobile-nav a{font-family:var(--font-display);font-size:2.5rem;font-weight:300;letter-spacing:.15em;color:var(--cream);text-decoration:none;text-transform:uppercase;opacity:.7;transition:opacity .3s}
 .mobile-nav a:hover{opacity:1;color:var(--gold)}
 
 /* ===== HERO ===== */
 .hero-standalone{position:relative;width:100%;height:100vh;background:var(--bg);display:flex;align-items:center;justify-content:center;overflow:hidden;z-index:10}
-.hero-bg-gradient{position:absolute;inset:0;background:radial-gradient(ellipse 80% 60% at 50% 40%,rgba(124,58,237,.07) 0%,transparent 70%)}
+.hero-bg-gradient{position:absolute;inset:0;background:radial-gradient(ellipse 80% 60% at 50% 40%,rgba(168,138,84,.07) 0%,transparent 70%)}
 .hero-content{position:relative;text-align:center;padding:0 5vw}
 .hero-label{display:block;font-family:var(--font-body);font-size:.65rem;font-weight:300;letter-spacing:.4em;color:var(--gold);text-transform:uppercase;margin-bottom:2rem;opacity:0}
 .hero-heading{font-family:var(--font-display);font-size:clamp(3rem,12vw,12rem);font-weight:300;line-height:.9;letter-spacing:-.02em;color:var(--cream);margin-bottom:1.5rem}
@@ -97,15 +97,15 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .section-beforeafter{justify-content:center;padding:0 5vw}
 .ba-container{position:relative;width:min(700px,80vw);aspect-ratio:3/4;border-radius:4px;overflow:hidden;cursor:ew-resize}
 .ba-side{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-size:clamp(1.5rem,3vw,3rem);font-weight:300}
-.ba-before{background:linear-gradient(135deg,#0e0e30 0%,#0B0B28 50%,#0e0e30 100%);color:var(--text-muted);z-index:1}
-.ba-before::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 50%,rgba(139,92,246,.08) 0%,transparent 60%)}
-.ba-after{background:linear-gradient(135deg,#0B0B28 0%,#13103a 50%,#0B0B28 100%);clip-path:inset(0 100% 0 0);z-index:2}
-.ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 50%,rgba(155,92,246,.18) 0%,transparent 60%)}
+.ba-before{background:linear-gradient(135deg,#181311 0%,#15110f 50%,#181311 100%);color:var(--text-muted);z-index:1}
+.ba-before::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 50%,rgba(201,169,110,.08) 0%,transparent 60%)}
+.ba-after{background:linear-gradient(135deg,#15110f 0%,#1c1613 50%,#15110f 100%);clip-path:inset(0 100% 0 0);z-index:2}
+.ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 50%,rgba(201,169,110,.18) 0%,transparent 60%)}
 .ba-before-label,.ba-after-label{position:absolute;bottom:2rem;font-family:var(--font-body);font-size:.6rem;letter-spacing:.35em;text-transform:uppercase;font-weight:300;z-index:5}
 .ba-before-label{left:2rem;color:var(--text-muted)}
 .ba-after-label{right:2rem;color:var(--gold)}
-.ba-line{position:absolute;top:0;bottom:0;width:1px;background:var(--gold);z-index:10;left:0%;transition:none;box-shadow:0 0 8px rgba(155,92,246,.5)}
-.ba-line::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:40px;height:40px;border:1px solid var(--gold);border-radius:50%;background:rgba(6,6,26,.7);backdrop-filter:blur(4px)}
+.ba-line{position:absolute;top:0;bottom:0;width:1px;background:var(--gold);z-index:10;left:0%;transition:none;box-shadow:0 0 8px rgba(201,169,110,.5)}
+.ba-line::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:40px;height:40px;border:1px solid var(--gold);border-radius:50%;background:rgba(12,10,9,.7);backdrop-filter:blur(4px)}
 .ba-line::after{content:'⟷';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--gold);font-size:.7rem}
 .ba-heading{position:absolute;top:-4rem;left:0;right:0;text-align:center;z-index:5}
 .ba-heading .section-label{margin-bottom:.6rem}
@@ -121,7 +121,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 /* ===== TREATMENTS ===== */
 .treatments-list{display:flex;flex-direction:column;gap:1.8rem}
-.treatment-item{display:flex;align-items:baseline;gap:1rem;padding-bottom:1.2rem;border-bottom:1px solid rgba(139,92,246,.12)}
+.treatment-item{display:flex;align-items:baseline;gap:1rem;padding-bottom:1.2rem;border-bottom:1px solid rgba(201,169,110,.12)}
 .treatment-name{font-family:var(--font-display);font-size:clamp(1.1rem,1.8vw,1.6rem);font-weight:400;color:var(--cream);flex:1}
 .treatment-price{font-family:var(--font-body);font-size:.75rem;letter-spacing:.15em;color:var(--gold);font-weight:300}
 .treatment-time{font-family:var(--font-body);font-size:.7rem;color:var(--text-muted);font-weight:200}
@@ -129,20 +129,20 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 /* ===== CTA ===== */
 .section-cta{justify-content:center;text-align:center;padding:0 5vw}
 .cta-inner{display:flex;flex-direction:column;align-items:center;gap:1.5rem}
-.cta-button{display:inline-flex;align-items:center;gap:.8rem;font-family:var(--font-body);font-size:.7rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;color:#fff;background:linear-gradient(135deg,#7C3AED,#9B5CF6);padding:1.1rem 3rem;border:none;cursor:pointer;text-decoration:none;border-radius:6px;box-shadow:0 0 28px rgba(124,58,237,.3);transition:box-shadow .3s,transform .25s}
-.cta-button:hover{box-shadow:0 0 40px rgba(124,58,237,.5);transform:scale(1.03)}
+.cta-button{display:inline-flex;align-items:center;gap:.8rem;font-family:var(--font-body);font-size:.7rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;color:#1a140e;background:linear-gradient(135deg,#a88a54,#c9a96e);padding:1.1rem 3rem;border:none;cursor:pointer;text-decoration:none;border-radius:6px;box-shadow:0 0 28px rgba(168,138,84,.3);transition:box-shadow .3s,transform .25s}
+.cta-button:hover{box-shadow:0 0 40px rgba(168,138,84,.5);transform:scale(1.03)}
 .cta-button svg{width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none}
 .cta-sub{font-size:.65rem;letter-spacing:.2em;color:var(--text-muted);font-weight:200;text-transform:uppercase}
 
 /* ===== FLOATING BOOK BUTTON ===== */
-#float-boka{position:fixed;bottom:max(2.5rem,env(safe-area-inset-bottom));right:2.5rem;z-index:90;background:linear-gradient(135deg,#7C3AED,#9B5CF6);color:#fff;font-family:var(--font-body);font-size:.65rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;padding:.85rem 1.8rem;border:none;cursor:pointer;border-radius:6px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 4px 24px rgba(124,58,237,.35)}
+#float-boka{position:fixed;bottom:max(2.5rem,env(safe-area-inset-bottom));right:2.5rem;z-index:90;background:linear-gradient(135deg,#a88a54,#c9a96e);color:#1a140e;font-family:var(--font-body);font-size:.65rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;padding:.85rem 1.8rem;border:none;cursor:pointer;border-radius:6px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 4px 24px rgba(168,138,84,.35)}
 #float-boka.visible{opacity:1;transform:translateY(0);pointer-events:auto}
-#float-boka:hover{box-shadow:0 4px 32px rgba(124,58,237,.55);transform:scale(1.04)}
+#float-boka:hover{box-shadow:0 4px 32px rgba(168,138,84,.55);transform:scale(1.04)}
 
 /* ===== BOOKING MODAL ===== */
-.modal-overlay{position:fixed;inset:0;z-index:500;background:rgba(6,6,26,.88);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:center;opacity:0;visibility:hidden;transition:all .4s ease;padding:1rem}
+.modal-overlay{position:fixed;inset:0;z-index:500;background:rgba(12,10,9,.88);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:center;opacity:0;visibility:hidden;transition:all .4s ease;padding:1rem}
 .modal-overlay.visible{opacity:1;visibility:visible}
-.modal-box{background:#0B0B28;border:1px solid rgba(139,92,246,.18);border-radius:14px;max-width:520px;width:100%;padding:3rem;position:relative;max-height:90vh;overflow-y:auto}
+.modal-box{background:#15110f;border:1px solid rgba(201,169,110,.18);border-radius:14px;max-width:520px;width:100%;padding:3rem;position:relative;max-height:90vh;overflow-y:auto}
 .modal-close{position:absolute;top:1.2rem;right:1.2rem;background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer;line-height:1;transition:color .3s;padding:10px}
 .modal-close:hover{color:var(--gold-light)}
 .modal-eyebrow{font-family:var(--font-body);font-size:.6rem;letter-spacing:.35em;color:var(--gold-light);text-transform:uppercase;margin-bottom:1rem}
@@ -152,12 +152,12 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .form-row{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
 .form-field{display:flex;flex-direction:column;gap:.5rem}
 .form-field label{font-size:.65rem;letter-spacing:.2em;text-transform:uppercase;color:var(--text-muted);font-weight:300}
-.form-field input,.form-field select,.form-field textarea{background:rgba(139,92,246,.05);border:1px solid rgba(139,92,246,.15);color:var(--cream);font-family:var(--font-body);font-size:1rem;font-weight:300;padding:.8rem 1rem;width:100%;outline:none;border-radius:6px;transition:border-color .3s;-webkit-appearance:none}
-.form-field select{background-color:#0B0B28;cursor:pointer}
-.form-field input:focus,.form-field select:focus,.form-field textarea:focus{border-color:rgba(155,92,246,.5)}
+.form-field input,.form-field select,.form-field textarea{background:rgba(201,169,110,.05);border:1px solid rgba(201,169,110,.15);color:var(--cream);font-family:var(--font-body);font-size:1rem;font-weight:300;padding:.8rem 1rem;width:100%;outline:none;border-radius:6px;transition:border-color .3s;-webkit-appearance:none}
+.form-field select{background-color:#15110f;cursor:pointer}
+.form-field input:focus,.form-field select:focus,.form-field textarea:focus{border-color:rgba(201,169,110,.5)}
 .form-field textarea{resize:vertical;min-height:90px}
-.form-submit{background:linear-gradient(135deg,#7C3AED,#9B5CF6);color:#fff;font-family:var(--font-body);font-size:.7rem;letter-spacing:.25em;text-transform:uppercase;font-weight:600;padding:1rem 2rem;border:none;cursor:pointer;border-radius:6px;box-shadow:0 0 20px rgba(124,58,237,.3);transition:box-shadow .3s,transform .2s;margin-top:.5rem;width:100%}
-.form-submit:hover{box-shadow:0 0 32px rgba(124,58,237,.5);transform:scale(1.02)}
+.form-submit{background:linear-gradient(135deg,#a88a54,#c9a96e);color:#1a140e;font-family:var(--font-body);font-size:.7rem;letter-spacing:.25em;text-transform:uppercase;font-weight:600;padding:1rem 2rem;border:none;cursor:pointer;border-radius:6px;box-shadow:0 0 20px rgba(168,138,84,.3);transition:box-shadow .3s,transform .2s;margin-top:.5rem;width:100%}
+.form-submit:hover{box-shadow:0 0 32px rgba(168,138,84,.5);transform:scale(1.02)}
 .modal-success{text-align:center;padding:2rem 0;display:none}
 .modal-success.visible{display:block}
 .success-icon{font-size:2.5rem;color:var(--gold-light);margin-bottom:1rem}
@@ -166,8 +166,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 /* ===== VISUAL ELEMENTS ===== */
 .floating-circle{position:fixed;border-radius:50%;pointer-events:none;z-index:2;opacity:0;will-change:transform}
-.floating-circle.c1{width:clamp(300px,40vw,600px);height:clamp(300px,40vw,600px);background:radial-gradient(circle,rgba(124,58,237,.06) 0%,transparent 70%);top:20%;right:-10%}
-.floating-circle.c2{width:clamp(200px,30vw,450px);height:clamp(200px,30vw,450px);background:radial-gradient(circle,rgba(196,181,253,.04) 0%,transparent 70%);bottom:10%;left:-5%}
+.floating-circle.c1{width:clamp(300px,40vw,600px);height:clamp(300px,40vw,600px);background:radial-gradient(circle,rgba(168,138,84,.06) 0%,transparent 70%);top:20%;right:-10%}
+.floating-circle.c2{width:clamp(200px,30vw,450px);height:clamp(200px,30vw,450px);background:radial-gradient(circle,rgba(224,196,138,.04) 0%,transparent 70%);bottom:10%;left:-5%}
 
 /* ===== GRAIN ===== */
 .grain{position:fixed;inset:0;z-index:999;pointer-events:none;opacity:.035;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");background-repeat:repeat;background-size:256px 256px}
@@ -179,7 +179,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   .hamburger{display:flex}
   .align-left,.align-right{padding-left:6vw;padding-right:6vw}
   .align-left .section-inner,.align-right .section-inner{max-width:100%}
-  .scroll-section.section-content .section-inner{background:rgba(6,6,26,.8);backdrop-filter:blur(8px);padding:2rem;border-radius:8px;border:1px solid rgba(139,92,246,.08)}
+  .scroll-section.section-content .section-inner{background:rgba(12,10,9,.8);backdrop-filter:blur(8px);padding:2rem;border-radius:8px;border:1px solid rgba(201,169,110,.08)}
   .stats-grid{grid-template-columns:repeat(2,1fr);gap:2rem}
   #scroll-container{height:600vh}
   .ba-container{width:90vw}
@@ -388,7 +388,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 <div class="modal-overlay" id="boka-modal">
   <div class="modal-box" style="max-width:480px">
     <button class="modal-close" onclick="closeModal()" aria-label="Stäng">✕</button>
-    <div style="display:inline-block;font-size:.6rem;letter-spacing:.25em;text-transform:uppercase;color:var(--gold-light);background:rgba(155,92,246,.1);border:1px solid rgba(155,92,246,.2);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.5rem">Demo av Bahko Byrå</div>
+    <div style="display:inline-block;font-size:.6rem;letter-spacing:.25em;text-transform:uppercase;color:var(--gold-light);background:rgba(201,169,110,.1);border:1px solid rgba(201,169,110,.2);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.5rem">Demo av Bahko Byrå</div>
     <h2 class="modal-title" style="font-size:clamp(1.6rem,4vw,2.4rem)">Vill du ha en<br>sida som denna?</h2>
     <p class="modal-sub">Boka ett kostnadsfritt 15-minuterssamtal med Mathias. Vi visar exakt hur din kliniks hemsida kan se ut.</p>
     <button
@@ -403,7 +403,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
       style="display:block;text-align:center;font-size:.75rem;color:var(--text-muted);text-decoration:none;letter-spacing:.1em;padding:.6rem;transition:color .3s"
       onmouseover="this.style.color='var(--gold-light)'" onmouseout="this.style.color='var(--text-muted)'"
     >Eller skicka ett mejl → mathias@bahkobyra.se</a>
-    <div style="margin-top:1.8rem;padding-top:1.2rem;border-top:1px solid rgba(139,92,246,.1);text-align:center;font-size:.65rem;letter-spacing:.15em;color:var(--text-muted)">
+    <div style="margin-top:1.8rem;padding-top:1.2rem;border-top:1px solid rgba(201,169,110,.1);text-align:center;font-size:.65rem;letter-spacing:.15em;color:var(--text-muted)">
       <a href="https://bahkobyra.se" target="_blank" style="color:var(--gold-light);text-decoration:none;font-weight:500">Bahko Byrå</a>
       &nbsp;·&nbsp; Synlighet som säljer.
     </div>
@@ -435,20 +435,20 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   function drawAmbient(p){
     const w=window.innerWidth,h=window.innerHeight;
     ctx.setTransform(dpr,0,0,dpr,0,0);
-    ctx.fillStyle="#06061A"; ctx.fillRect(0,0,w,h);
+    ctx.fillStyle="#0c0a09"; ctx.fillRect(0,0,w,h);
     const ox=w*(0.3+Math.sin(p*Math.PI*2)*0.2), oy=h*(0.35+Math.cos(p*Math.PI*1.5)*0.15), or=Math.min(w,h)*(0.3+p*0.15);
     const g1=ctx.createRadialGradient(ox,oy,0,ox,oy,or);
-    g1.addColorStop(0,"rgba(124,58,237,0.08)"); g1.addColorStop(.5,"rgba(155,92,246,0.04)"); g1.addColorStop(1,"transparent");
+    g1.addColorStop(0,"rgba(168,138,84,0.08)"); g1.addColorStop(.5,"rgba(201,169,110,0.04)"); g1.addColorStop(1,"transparent");
     ctx.fillStyle=g1; ctx.fillRect(0,0,w,h);
     const o2x=w*(0.7-Math.sin(p*Math.PI*1.8)*0.15), o2y=h*(0.6+Math.cos(p*Math.PI*2.2)*0.1), o2r=Math.min(w,h)*0.25;
     const g2=ctx.createRadialGradient(o2x,o2y,0,o2x,o2y,o2r);
-    g2.addColorStop(0,"rgba(196,181,253,0.05)"); g2.addColorStop(1,"transparent");
+    g2.addColorStop(0,"rgba(224,196,138,0.05)"); g2.addColorStop(1,"transparent");
     ctx.fillStyle=g2; ctx.fillRect(0,0,w,h);
     const sy=h*(0.3+p*0.4), sg=ctx.createLinearGradient(0,sy,w,sy);
-    sg.addColorStop(0,"transparent"); sg.addColorStop(.3,"rgba(124,58,237,0.02)"); sg.addColorStop(.7,"rgba(124,58,237,0.02)"); sg.addColorStop(1,"transparent");
+    sg.addColorStop(0,"transparent"); sg.addColorStop(.3,"rgba(168,138,84,0.02)"); sg.addColorStop(.7,"rgba(168,138,84,0.02)"); sg.addColorStop(1,"transparent");
     ctx.fillStyle=sg; ctx.fillRect(0,sy-100,w,200);
     const vg=ctx.createRadialGradient(w/2,h/2,Math.min(w,h)*0.2,w/2,h/2,Math.max(w,h)*0.7);
-    vg.addColorStop(0,"transparent"); vg.addColorStop(1,"rgba(6,6,26,0.45)");
+    vg.addColorStop(0,"transparent"); vg.addColorStop(1,"rgba(12,10,9,0.45)");
     ctx.fillStyle=vg; ctx.fillRect(0,0,w,h);
   }
 


### PR DESCRIPTION
## Vad
Rethemar Élara-demon (`kliniker/elara-klinik-demo-v2.html`) så den matchar bahkobyra.se. Tidigare hade demon ett **lila** tema på kall blå-svart med Inter — nu är den i Bahkos **guld på varm svart** med Outfit.

## Ändringar (bara färg + typsnitt — ingen layout eller animation rörd)
- Accentfärg: lila `#9B5CF6` → guld `#c9a96e` (+ ljusguld `#e0c48a`)
- Bakgrund: blå-svart `#06061A` → varm svart `#0c0a09`
- Brödtypsnitt: **Inter → Outfit** (rubrik = Cormorant Garamond, oförändrad)
- Knappar: guld-gradient med mörk text (som startsidan) istället för lila med vit text
- Alla CSS-variabler, gradienter och canvas-gradienter omfärgade till varma toner

Demon använder inga bilder (allt är CSS/canvas), så omfärgningen är komplett.

## Var det syns
bahkobyra.cloud (demons egen domän) + länkarna "Se Live Demo" / "Öppna Demo" på startsidan.

## Test efter merge
Öppna bahkobyra.cloud och scrolla igenom — allt ska kännas som samma varumärke som bahkobyra.se (guld/svart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
