### PR TITLE
Brighten Élara demo + AI before/after image + smoother scroll

### DIFF
--- a/kliniker/elara-klinik-demo-v2.html
+++ b/kliniker/elara-klinik-demo-v2.html
@@ -6,19 +6,20 @@
 <title>ÉLARA KLINIK — Naturlig Skönhet, Förhöjd</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://d8j0ntlcm91z4.cloudfront.net" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root{
-  --bg:#0c0a09;
-  --bg-warm:#15110f;
-  --cream:#f0ece4;
-  --gold:#c9a96e;
-  --gold-light:#e0c48a;
-  --rose:#d8bd8f;
-  --text-primary:#f0ece4;
-  --text-secondary:rgba(240,236,228,.5);
-  --text-muted:rgba(240,236,228,.28);
+  --bg:#FBF6EF;
+  --bg-warm:#F5E9DF;
+  --cream:#3a2c24;
+  --gold:#b8914c;
+  --gold-light:#caa25c;
+  --rose:#e3a39c;
+  --text-primary:#3a2c24;
+  --text-secondary:rgba(58,44,36,.62);
+  --text-muted:rgba(58,44,36,.42);
   --font-display:'Cormorant Garamond',serif;
   --font-body:'Outfit',sans-serif;
 }
@@ -35,7 +36,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 /* ===== HEADER ===== */
 .site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1.8rem,env(safe-area-inset-top)) 3vw 1.8rem;display:flex;justify-content:space-between;align-items:center}
-.site-header.scrolled{background:rgba(12,10,9,.88);backdrop-filter:blur(20px);border-bottom:1px solid rgba(201,169,110,.1)}
+.site-header.scrolled{background:rgba(251,246,239,.82);backdrop-filter:blur(20px);border-bottom:1px solid rgba(58,44,36,.08)}
 .header-logo{font-family:var(--font-display);font-size:1.1rem;font-weight:400;letter-spacing:.35em;color:var(--cream);text-transform:uppercase;text-decoration:none}
 .header-nav{display:flex;gap:2.5rem;align-items:center}
 .header-nav a{font-family:var(--font-body);font-size:.7rem;font-weight:300;letter-spacing:.2em;color:var(--cream);text-decoration:none;text-transform:uppercase;opacity:.7;transition:opacity .3s}
@@ -47,14 +48,14 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .hamburger.open span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger.open span:nth-child(2){opacity:0}
 .hamburger.open span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
-.mobile-nav{position:fixed;inset:0;background:rgba(12,10,9,.97);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.5rem;opacity:0;visibility:hidden;transition:all .4s ease}
+.mobile-nav{position:fixed;inset:0;background:rgba(251,246,239,.97);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.5rem;opacity:0;visibility:hidden;transition:all .4s ease}
 .mobile-nav.open{opacity:1;visibility:visible}
 .mobile-nav a{font-family:var(--font-display);font-size:2.5rem;font-weight:300;letter-spacing:.15em;color:var(--cream);text-decoration:none;text-transform:uppercase;opacity:.7;transition:opacity .3s}
 .mobile-nav a:hover{opacity:1;color:var(--gold)}
 
 /* ===== HERO ===== */
 .hero-standalone{position:relative;width:100%;height:100vh;background:var(--bg);display:flex;align-items:center;justify-content:center;overflow:hidden;z-index:10}
-.hero-bg-gradient{position:absolute;inset:0;background:radial-gradient(ellipse 80% 60% at 50% 40%,rgba(168,138,84,.07) 0%,transparent 70%)}
+.hero-bg-gradient{position:absolute;inset:0;background:radial-gradient(ellipse 80% 60% at 50% 40%,rgba(227,163,156,.16) 0%,transparent 70%)}
 .hero-content{position:relative;text-align:center;padding:0 5vw}
 .hero-label{display:block;font-family:var(--font-body);font-size:.65rem;font-weight:300;letter-spacing:.4em;color:var(--gold);text-transform:uppercase;margin-bottom:2rem;opacity:0}
 .hero-heading{font-family:var(--font-display);font-size:clamp(3rem,12vw,12rem);font-weight:300;line-height:.9;letter-spacing:-.02em;color:var(--cream);margin-bottom:1.5rem}
@@ -76,7 +77,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 /* ===== MARQUEE ===== */
 .marquee-wrap{position:fixed;z-index:4;pointer-events:none;width:100%;opacity:0;will-change:opacity}
 .marquee-wrap.marquee-top{top:15%;left:0}
-.marquee-text{white-space:nowrap;font-family:var(--font-display);font-size:clamp(4rem,12vw,14vw);font-weight:300;font-style:italic;color:transparent;-webkit-text-stroke:1px rgba(201,169,110,.25);letter-spacing:.02em;will-change:transform}
+.marquee-text{white-space:nowrap;font-family:var(--font-display);font-size:clamp(4rem,12vw,14vw);font-weight:300;font-style:italic;color:transparent;-webkit-text-stroke:1px rgba(184,145,76,.45);letter-spacing:.02em;will-change:transform}
 
 /* ===== SCROLL CONTAINER ===== */
 #scroll-container{position:relative;width:100%;height:900vh;z-index:5}
@@ -97,15 +98,17 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .section-beforeafter{justify-content:center;padding:0 5vw}
 .ba-container{position:relative;width:min(700px,80vw);aspect-ratio:3/4;border-radius:4px;overflow:hidden;cursor:ew-resize}
 .ba-side{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-size:clamp(1.5rem,3vw,3rem);font-weight:300}
-.ba-before{background:linear-gradient(135deg,#181311 0%,#15110f 50%,#181311 100%);color:var(--text-muted);z-index:1}
-.ba-before::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 50%,rgba(201,169,110,.08) 0%,transparent 60%)}
-.ba-after{background:linear-gradient(135deg,#15110f 0%,#1c1613 50%,#15110f 100%);clip-path:inset(0 100% 0 0);z-index:2}
-.ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 50%,rgba(201,169,110,.18) 0%,transparent 60%)}
-.ba-before-label,.ba-after-label{position:absolute;bottom:2rem;font-family:var(--font-body);font-size:.6rem;letter-spacing:.35em;text-transform:uppercase;font-weight:300;z-index:5}
-.ba-before-label{left:2rem;color:var(--text-muted)}
-.ba-after-label{right:2rem;color:var(--gold)}
+.ba-before{z-index:1}
+.ba-before::before{content:'';position:absolute;inset:0;background:#efe2d6 url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260604_182756_1a6a55a5-b2f0-4869-833b-a0dcd83a9a40.png') center/cover;filter:grayscale(.5) brightness(.9) contrast(.95)}
+.ba-before::after{content:'';position:absolute;inset:0;background:rgba(58,44,36,.14)}
+.ba-after{clip-path:inset(0 100% 0 0);z-index:2}
+.ba-after::before{content:'';position:absolute;inset:0;background:#efe2d6 url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260604_182756_1a6a55a5-b2f0-4869-833b-a0dcd83a9a40.png') center/cover;filter:saturate(1.15) brightness(1.05)}
+.ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 45%,rgba(227,163,156,.18) 0%,transparent 60%)}
+.ba-before-label,.ba-after-label{position:absolute;bottom:1.6rem;font-family:var(--font-body);font-size:.58rem;letter-spacing:.28em;text-transform:uppercase;font-weight:500;z-index:5;background:rgba(255,253,249,.85);padding:.45rem .95rem;border-radius:999px;backdrop-filter:blur(4px)}
+.ba-before-label{left:1.6rem;color:var(--text-secondary)}
+.ba-after-label{right:1.6rem;color:var(--gold)}
 .ba-line{position:absolute;top:0;bottom:0;width:1px;background:var(--gold);z-index:10;left:0%;transition:none;box-shadow:0 0 8px rgba(201,169,110,.5)}
-.ba-line::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:40px;height:40px;border:1px solid var(--gold);border-radius:50%;background:rgba(12,10,9,.7);backdrop-filter:blur(4px)}
+.ba-line::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:40px;height:40px;border:1px solid var(--gold);border-radius:50%;background:rgba(251,246,239,.88);backdrop-filter:blur(4px)}
 .ba-line::after{content:'⟷';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--gold);font-size:.7rem}
 .ba-heading{position:absolute;top:-4rem;left:0;right:0;text-align:center;z-index:5}
 .ba-heading .section-label{margin-bottom:.6rem}
@@ -140,9 +143,9 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 #float-boka:hover{box-shadow:0 4px 32px rgba(168,138,84,.55);transform:scale(1.04)}
 
 /* ===== BOOKING MODAL ===== */
-.modal-overlay{position:fixed;inset:0;z-index:500;background:rgba(12,10,9,.88);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:center;opacity:0;visibility:hidden;transition:all .4s ease;padding:1rem}
+.modal-overlay{position:fixed;inset:0;z-index:500;background:rgba(58,44,36,.45);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:center;opacity:0;visibility:hidden;transition:all .4s ease;padding:1rem}
 .modal-overlay.visible{opacity:1;visibility:visible}
-.modal-box{background:#15110f;border:1px solid rgba(201,169,110,.18);border-radius:14px;max-width:520px;width:100%;padding:3rem;position:relative;max-height:90vh;overflow-y:auto}
+.modal-box{background:#fffdf9;border:1px solid rgba(201,169,110,.3);border-radius:14px;max-width:520px;width:100%;padding:3rem;position:relative;max-height:90vh;overflow-y:auto;box-shadow:0 30px 90px rgba(58,44,36,.22)}
 .modal-close{position:absolute;top:1.2rem;right:1.2rem;background:none;border:none;color:var(--text-muted);font-size:1.2rem;cursor:pointer;line-height:1;transition:color .3s;padding:10px}
 .modal-close:hover{color:var(--gold-light)}
 .modal-eyebrow{font-family:var(--font-body);font-size:.6rem;letter-spacing:.35em;color:var(--gold-light);text-transform:uppercase;margin-bottom:1rem}
@@ -152,8 +155,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .form-row{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
 .form-field{display:flex;flex-direction:column;gap:.5rem}
 .form-field label{font-size:.65rem;letter-spacing:.2em;text-transform:uppercase;color:var(--text-muted);font-weight:300}
-.form-field input,.form-field select,.form-field textarea{background:rgba(201,169,110,.05);border:1px solid rgba(201,169,110,.15);color:var(--cream);font-family:var(--font-body);font-size:1rem;font-weight:300;padding:.8rem 1rem;width:100%;outline:none;border-radius:6px;transition:border-color .3s;-webkit-appearance:none}
-.form-field select{background-color:#15110f;cursor:pointer}
+.form-field input,.form-field select,.form-field textarea{background:#faf3ea;border:1px solid rgba(58,44,36,.16);color:var(--cream);font-family:var(--font-body);font-size:1rem;font-weight:300;padding:.8rem 1rem;width:100%;outline:none;border-radius:6px;transition:border-color .3s;-webkit-appearance:none}
+.form-field select{background-color:#fffdf9;cursor:pointer}
 .form-field input:focus,.form-field select:focus,.form-field textarea:focus{border-color:rgba(201,169,110,.5)}
 .form-field textarea{resize:vertical;min-height:90px}
 .form-submit{background:linear-gradient(135deg,#a88a54,#c9a96e);color:#1a140e;font-family:var(--font-body);font-size:.7rem;letter-spacing:.25em;text-transform:uppercase;font-weight:600;padding:1rem 2rem;border:none;cursor:pointer;border-radius:6px;box-shadow:0 0 20px rgba(168,138,84,.3);transition:box-shadow .3s,transform .2s;margin-top:.5rem;width:100%}
@@ -166,8 +169,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 /* ===== VISUAL ELEMENTS ===== */
 .floating-circle{position:fixed;border-radius:50%;pointer-events:none;z-index:2;opacity:0;will-change:transform}
-.floating-circle.c1{width:clamp(300px,40vw,600px);height:clamp(300px,40vw,600px);background:radial-gradient(circle,rgba(168,138,84,.06) 0%,transparent 70%);top:20%;right:-10%}
-.floating-circle.c2{width:clamp(200px,30vw,450px);height:clamp(200px,30vw,450px);background:radial-gradient(circle,rgba(224,196,138,.04) 0%,transparent 70%);bottom:10%;left:-5%}
+.floating-circle.c1{width:clamp(300px,40vw,600px);height:clamp(300px,40vw,600px);background:radial-gradient(circle,rgba(227,163,156,.16) 0%,transparent 70%);top:20%;right:-10%}
+.floating-circle.c2{width:clamp(200px,30vw,450px);height:clamp(200px,30vw,450px);background:radial-gradient(circle,rgba(202,162,92,.13) 0%,transparent 70%);bottom:10%;left:-5%}
 
 /* ===== GRAIN ===== */
 .grain{position:fixed;inset:0;z-index:999;pointer-events:none;opacity:.035;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");background-repeat:repeat;background-size:256px 256px}
@@ -179,7 +182,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   .hamburger{display:flex}
   .align-left,.align-right{padding-left:6vw;padding-right:6vw}
   .align-left .section-inner,.align-right .section-inner{max-width:100%}
-  .scroll-section.section-content .section-inner{background:rgba(12,10,9,.8);backdrop-filter:blur(8px);padding:2rem;border-radius:8px;border:1px solid rgba(201,169,110,.08)}
+  .scroll-section.section-content .section-inner{background:rgba(255,253,249,.72);backdrop-filter:blur(8px);padding:2rem;border-radius:8px;border:1px solid rgba(58,44,36,.08)}
   .stats-grid{grid-template-columns:repeat(2,1fr);gap:2rem}
   #scroll-container{height:600vh}
   .ba-container{width:90vw}
@@ -282,19 +285,9 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
       </div>
       <div class="ba-container" id="ba-container">
         <div class="ba-side ba-before">
-          <div style="text-align:center;z-index:2;position:relative">
-            <div style="width:120px;height:120px;border-radius:50%;border:1px solid rgba(107,97,89,.3);margin:0 auto 1rem;display:flex;align-items:center;justify-content:center">
-              <span style="font-size:.7rem;letter-spacing:.2em;color:var(--text-muted);font-family:var(--font-body);text-transform:uppercase">Före</span>
-            </div>
-          </div>
           <span class="ba-before-label">Före behandling</span>
         </div>
         <div class="ba-side ba-after" id="ba-after">
-          <div style="text-align:center;z-index:2;position:relative">
-            <div style="width:120px;height:120px;border-radius:50%;border:1px solid rgba(201,169,110,.4);margin:0 auto 1rem;display:flex;align-items:center;justify-content:center;box-shadow:0 0 60px rgba(201,169,110,.08)">
-              <span style="font-size:.7rem;letter-spacing:.2em;color:var(--gold);font-family:var(--font-body);text-transform:uppercase">Efter</span>
-            </div>
-          </div>
           <span class="ba-after-label">Efter behandling</span>
         </div>
         <div class="ba-line" id="ba-line"></div>
@@ -418,7 +411,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   "use strict";
 
   // ===== LENIS =====
-  const lenis = new Lenis({ duration:1.4, easing:t=>Math.min(1,1.001-Math.pow(2,-10*t)), smoothWheel:true });
+  const lenis = new Lenis({ duration:1.15, easing:t=>1-Math.pow(1-t,3), smoothWheel:true, syncTouch:true, touchMultiplier:1.5 });
   lenis.on("scroll", ScrollTrigger.update);
   gsap.ticker.add(time => lenis.raf(time*1000));
   gsap.ticker.lagSmoothing(0);
@@ -435,20 +428,20 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   function drawAmbient(p){
     const w=window.innerWidth,h=window.innerHeight;
     ctx.setTransform(dpr,0,0,dpr,0,0);
-    ctx.fillStyle="#0c0a09"; ctx.fillRect(0,0,w,h);
+    ctx.fillStyle="#FBF6EF"; ctx.fillRect(0,0,w,h);
     const ox=w*(0.3+Math.sin(p*Math.PI*2)*0.2), oy=h*(0.35+Math.cos(p*Math.PI*1.5)*0.15), or=Math.min(w,h)*(0.3+p*0.15);
     const g1=ctx.createRadialGradient(ox,oy,0,ox,oy,or);
-    g1.addColorStop(0,"rgba(168,138,84,0.08)"); g1.addColorStop(.5,"rgba(201,169,110,0.04)"); g1.addColorStop(1,"transparent");
+    g1.addColorStop(0,"rgba(227,163,156,0.18)"); g1.addColorStop(.5,"rgba(202,162,92,0.10)"); g1.addColorStop(1,"transparent");
     ctx.fillStyle=g1; ctx.fillRect(0,0,w,h);
     const o2x=w*(0.7-Math.sin(p*Math.PI*1.8)*0.15), o2y=h*(0.6+Math.cos(p*Math.PI*2.2)*0.1), o2r=Math.min(w,h)*0.25;
     const g2=ctx.createRadialGradient(o2x,o2y,0,o2x,o2y,o2r);
-    g2.addColorStop(0,"rgba(224,196,138,0.05)"); g2.addColorStop(1,"transparent");
+    g2.addColorStop(0,"rgba(227,163,156,0.12)"); g2.addColorStop(1,"transparent");
     ctx.fillStyle=g2; ctx.fillRect(0,0,w,h);
     const sy=h*(0.3+p*0.4), sg=ctx.createLinearGradient(0,sy,w,sy);
-    sg.addColorStop(0,"transparent"); sg.addColorStop(.3,"rgba(168,138,84,0.02)"); sg.addColorStop(.7,"rgba(168,138,84,0.02)"); sg.addColorStop(1,"transparent");
+    sg.addColorStop(0,"transparent"); sg.addColorStop(.3,"rgba(202,162,92,0.05)"); sg.addColorStop(.7,"rgba(202,162,92,0.05)"); sg.addColorStop(1,"transparent");
     ctx.fillStyle=sg; ctx.fillRect(0,sy-100,w,200);
     const vg=ctx.createRadialGradient(w/2,h/2,Math.min(w,h)*0.2,w/2,h/2,Math.max(w,h)*0.7);
-    vg.addColorStop(0,"transparent"); vg.addColorStop(1,"rgba(12,10,9,0.45)");
+    vg.addColorStop(0,"transparent"); vg.addColorStop(1,"rgba(180,150,120,0.10)");
     ctx.fillStyle=vg; ctx.fillRect(0,0,w,h);
   }
 
@@ -581,9 +574,9 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
       onUpdate:self=>{
         const p=self.progress,e=0.56,l=0.74,fr=0.04;
         let o=0;
-        if(p>=e-fr&&p<=e)o=((p-(e-fr))/fr)*0.9;
-        else if(p>e&&p<l)o=0.9;
-        else if(p>=l&&p<=l+fr)o=0.9*(1-(p-l)/fr);
+        if(p>=e-fr&&p<=e)o=((p-(e-fr))/fr)*0.5;
+        else if(p>e&&p<l)o=0.5;
+        else if(p>=l&&p<=l+fr)o=0.5*(1-(p-l)/fr);
         overlay.style.opacity=o;
       }
     });


### PR DESCRIPTION
## Vad
Gör om Élara-demon (`kliniker/elara-klinik-demo-v2.html`) ljusare, gladare och vackrare — och lägger in en riktig AI-genererad före/efter-bild i sektion 002.

## Ändringar
**1. Ljust, varmt tema (var för mörkt)**
- Bakgrund: nästan-svart → ivory `#FBF6EF`
- Text: ljus → djup varm brun `#3a2c24`
- Accenter: guld `#b8914c` + mjuk rosa `#e3a39c` (glada toner)
- Omfärgat: header, mobilmeny, modal (nu ljus/vit), formulärfält, flytande färgcirklar, canvas-ambient (rosa/guld-bloom på cream), vinjett

**2. Före/efter-bild — sektion 002 ("Ser bra ut. Känns som du.")**
- AI-porträtt genererat med **Higgsfield** (nano_banana_pro), ljust beauty-editorial
- Samma bild på båda sidor av slidern: "före" = dämpad/gråare, "efter" = lysande/mättad + mjuk rosa glow → en trovärdig hudtransformation när man drar i slidern
- Läsbara etikett-pills ("Före behandling" / "Efter behandling")

**3. Mjukare scroll**
- Lenis: cubic ease-out + `syncTouch` för mjuk mobilscroll
- Nedtonad mörk mid-scroll-overlay (passar ljust tema)

## Var det syns
bahkobyra.cloud (demons domän) + "Se Live Demo"-länkarna på startsidan.

## ⚠️ Granska live
Det här är en stor visuell omarbetning av en komplex scroll/canvas-sida som jag inte kunnat se köra. **Öppna bahkobyra.cloud efter merge och scrolla igenom.** Säg till om någon specifik scroll-glitch finns kvar (beskriv var) så fixar jag den punktvis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
