### PR TITLE
Polish: Ken Burns hero, marquee reveal, CTA glow, stat labels, scrollcue bounce

### DIFF
--- a/bahkobyra/css/style.css
+++ b/bahkobyra/css/style.css
@@ -184,7 +184,8 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
 .hero{position:relative;min-height:100svh;display:flex;flex-direction:column;justify-content:center;
   padding:9rem var(--gut) 7rem;overflow:hidden;background:var(--navy-3);color:var(--paper)}
 .hero-img{position:absolute;inset:0;z-index:0}
-.hero-img img{width:100%;height:100%;object-fit:cover;opacity:.9}
+.hero-img img{width:100%;height:100%;object-fit:cover;opacity:.9;animation:kenBurns 10s cubic-bezier(.2,0,.6,1) forwards}
+@keyframes kenBurns{from{transform:scale(1.09)}to{transform:scale(1.0)}}
 .hero-img::after{content:'';position:absolute;inset:0;
   background:
     linear-gradient(90deg,rgba(13,16,35,.82) 0%,rgba(13,16,35,.5) 42%,transparent 74%),
@@ -212,6 +213,8 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
 .scrollcue .ln::after{content:'';position:absolute;inset:0 100% 0 0;background:var(--gold-lt);animation:cue 2.4s var(--ease-io) infinite}
 @keyframes cue{0%{inset:0 100% 0 0}50%{inset:0 0 0 0}100%{inset:0 0 0 100%}}
 .scrollcue span{font-size:.56rem;letter-spacing:.28em;text-transform:uppercase}
+.scrollcue span:last-child{animation:scrollBounce 2.2s ease-in-out infinite}
+@keyframes scrollBounce{0%,100%{transform:translateY(0)}50%{transform:translateY(5px)}}
 
 /* ── 10. MARQUEE ─────────────────────────────────────────── */
 .marquee{background:var(--navy);border-top:1px solid var(--paper-line);border-bottom:1px solid var(--paper-line);

--- a/bahkobyra/js/main.js
+++ b/bahkobyra/js/main.js
@@ -375,6 +375,39 @@
     setTimeout(() => { show(); setInterval(show, 90000); }, 18000);
   }
 
+  /* ── EXTRAS: marquee, CTA glow, stat labels, proc hint ─── */
+  function initExtras() {
+    if (!hasST || reduce) return;
+
+    // marquee band wipes in from left
+    gsap.fromTo('.marquee',
+      { clipPath: 'inset(0 100% 0 0)' },
+      { clipPath: 'inset(0 0% 0 0)', duration: 1.1, ease: 'power4.inOut',
+        scrollTrigger: { trigger: '.marquee', start: 'top 96%' } }
+    );
+
+    // CTA glow scales up as section enters
+    gsap.fromTo('.cta .glow',
+      { scale: 0.4, opacity: 0 },
+      { scale: 1, opacity: 1, duration: 2.2, ease: 'power2.out',
+        scrollTrigger: { trigger: '.cta', start: 'top 75%' } }
+    );
+
+    // stat labels fade in after the number punch
+    gsap.fromTo('.stat-l',
+      { opacity: 0, y: 8 },
+      { opacity: 1, y: 0, duration: .75, ease: 'power3.out', stagger: .13, delay: .9,
+        scrollTrigger: { trigger: '.stats', start: 'top 82%' } }
+    );
+
+    // process hint line slides in
+    gsap.fromTo('.proc-hint',
+      { opacity: 0, x: -24 },
+      { opacity: 1, x: 0, duration: .9, ease: 'expo.out',
+        scrollTrigger: { trigger: '.proc-hint', start: 'top 88%' } }
+    );
+  }
+
   /* ── AUDIT REVEAL ──────────────────────────────────────── */
   function initAuditReveal() {
     if (!hasST || reduce) return;
@@ -427,6 +460,7 @@
     initReveals();
     initCounters();
     initStatsPunch();
+    initExtras();
     initParallax();
     initProcess();
     initMarquee();


### PR DESCRIPTION
## Ändringar
- **Hero-bild**: Ken Burns zoom-out (1.09→1.0 över 10s) — ger ett levande, cinematiskt intryck direkt vid sidladdning
- **Scrollcue**: subtil bounce på "Scrolla"-texten
- **Marquee-band**: clip-path wipe-in från vänster när det scrollas in i viewport
- **CTA-glöd**: glow-orben skalas in från 0.4 (2.2s) när sektionen visas
- **Stat-labels**: staggerad fade-in med 0.9s fördröjning efter nummer-punchen
- **Process-hint**: glider in från vänster vid scroll

https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7)_