### PR TITLE
Demo (bahkobyra.cloud): matcha bahkobyra.se, ljusare, mer magi + fixa före/efter-bild

### DIFF
--- a/kliniker/elara-klinik-demo-v2.html
+++ b/kliniker/elara-klinik-demo-v2.html
@@ -11,20 +11,23 @@
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root{
-  --bg:#FBF6EF;
-  --bg-warm:#F5E9DF;
-  --cream:#3a2c24;
-  --gold:#b8914c;
-  --gold-light:#caa25c;
-  --rose:#e3a39c;
-  --text-primary:#3a2c24;
-  --text-secondary:rgba(58,44,36,.62);
-  --text-muted:rgba(58,44,36,.42);
+  --bg:#FCFAF5;
+  --bg-warm:#F4ECE0;
+  --ink:#181C38;
+  --cream:#181C38;            /* heading/ink color → navy to match bahkobyra.se */
+  --gold:#C9A96E;
+  --gold-light:#E3C88E;
+  --gold-dk:#B08F4D;
+  --rose:#E3A39C;
+  --text-primary:#181C38;
+  --text-secondary:rgba(24,28,56,.62);
+  --text-muted:rgba(24,28,56,.40);
   --font-display:'Cormorant Garamond',serif;
   --font-body:'Outfit',sans-serif;
 }
 html{background:var(--bg)}
 body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body);overflow-x:hidden;-webkit-font-smoothing:antialiased}
+::selection{background:var(--gold);color:#fffdf9}
 
 /* ===== LOADER ===== */
 #loader{position:fixed;inset:0;z-index:9999;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center;transition:opacity .6s ease,visibility .6s ease}
@@ -36,11 +39,14 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 /* ===== HEADER ===== */
 .site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1.8rem,env(safe-area-inset-top)) 3vw 1.8rem;display:flex;justify-content:space-between;align-items:center}
-.site-header.scrolled{background:rgba(251,246,239,.82);backdrop-filter:blur(20px);border-bottom:1px solid rgba(58,44,36,.08)}
-.header-logo{font-family:var(--font-display);font-size:1.1rem;font-weight:400;letter-spacing:.35em;color:var(--cream);text-transform:uppercase;text-decoration:none}
+.site-header.scrolled{background:rgba(252,250,245,.82);backdrop-filter:blur(20px) saturate(1.3);-webkit-backdrop-filter:blur(20px) saturate(1.3);border-bottom:1px solid rgba(201,169,110,.18)}
+.header-logo{font-family:var(--font-display);font-size:1.1rem;font-weight:500;letter-spacing:.35em;color:var(--cream);text-transform:uppercase;text-decoration:none}
+.header-logo em,.header-logo{transition:color .3s}
 .header-nav{display:flex;gap:2.5rem;align-items:center}
-.header-nav a{font-family:var(--font-body);font-size:.7rem;font-weight:300;letter-spacing:.2em;color:var(--cream);text-decoration:none;text-transform:uppercase;opacity:.7;transition:opacity .3s}
-.header-nav a:hover{opacity:1}
+.header-nav a{position:relative;font-family:var(--font-body);font-size:.7rem;font-weight:400;letter-spacing:.2em;color:var(--cream);text-decoration:none;text-transform:uppercase;opacity:.72;transition:opacity .3s,color .3s}
+.header-nav a::after{content:'';position:absolute;left:0;bottom:-5px;height:1px;width:0;background:var(--gold);transition:width .35s cubic-bezier(.22,1,.36,1)}
+.header-nav a:hover{opacity:1;color:var(--gold-dk)}
+.header-nav a:hover::after{width:100%}
 
 /* Hamburger */
 .hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:10px;margin:-10px;background:none;border:none;z-index:200}
@@ -60,6 +66,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .hero-label{display:block;font-family:var(--font-body);font-size:.65rem;font-weight:300;letter-spacing:.4em;color:var(--gold);text-transform:uppercase;margin-bottom:2rem;opacity:0}
 .hero-heading{font-family:var(--font-display);font-size:clamp(3rem,12vw,12rem);font-weight:300;line-height:.9;letter-spacing:-.02em;color:var(--cream);margin-bottom:1.5rem}
 .hero-heading .word{display:inline-block;opacity:0;transform:translateY(60px)}
+.hero-heading .accent{font-style:italic;font-weight:400;background:linear-gradient(108deg,var(--gold-light),var(--gold) 55%,var(--gold-dk));background-size:220% auto;-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;animation:goldShimmer 7s linear infinite}
+@keyframes goldShimmer{to{background-position:220% center}}
 .hero-tagline{font-family:var(--font-body);font-size:clamp(.8rem,1.2vw,1rem);font-weight:200;letter-spacing:.15em;color:var(--text-secondary);text-transform:uppercase;opacity:0}
 .hero-scroll-indicator{position:absolute;bottom:3rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0}
 .hero-scroll-indicator span{font-size:.6rem;letter-spacing:.3em;color:var(--text-muted);text-transform:uppercase;font-weight:300}
@@ -77,7 +85,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 /* ===== MARQUEE ===== */
 .marquee-wrap{position:fixed;z-index:4;pointer-events:none;width:100%;opacity:0;will-change:opacity}
 .marquee-wrap.marquee-top{top:15%;left:0}
-.marquee-text{white-space:nowrap;font-family:var(--font-display);font-size:clamp(4rem,12vw,14vw);font-weight:300;font-style:italic;color:transparent;-webkit-text-stroke:1px rgba(184,145,76,.45);letter-spacing:.02em;will-change:transform}
+.marquee-text{white-space:nowrap;font-family:var(--font-display);font-size:clamp(4rem,12vw,14vw);font-weight:300;font-style:italic;color:transparent;-webkit-text-stroke:1px rgba(201,169,110,.5);letter-spacing:.02em;will-change:transform}
 
 /* ===== SCROLL CONTAINER ===== */
 #scroll-container{position:relative;width:100%;height:900vh;z-index:5}
@@ -99,10 +107,10 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .ba-container{position:relative;width:min(700px,80vw);aspect-ratio:3/4;border-radius:4px;overflow:hidden;cursor:ew-resize}
 .ba-side{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-size:clamp(1.5rem,3vw,3rem);font-weight:300}
 .ba-before{z-index:1}
-.ba-before::before{content:'';position:absolute;inset:0;background:#efe2d6 url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260604_182756_1a6a55a5-b2f0-4869-833b-a0dcd83a9a40.png') center/cover;filter:grayscale(.5) brightness(.9) contrast(.95)}
+.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_172630_e3c45b12-cb11-4065-93eb-3e487e59a556.png') center/cover no-repeat,linear-gradient(160deg,#f0ddc9,#e6c9b0 55%,#d3b196);filter:grayscale(.55) brightness(.92) contrast(.96)}
 .ba-before::after{content:'';position:absolute;inset:0;background:rgba(58,44,36,.14)}
 .ba-after{clip-path:inset(0 100% 0 0);z-index:2}
-.ba-after::before{content:'';position:absolute;inset:0;background:#efe2d6 url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260604_182756_1a6a55a5-b2f0-4869-833b-a0dcd83a9a40.png') center/cover;filter:saturate(1.15) brightness(1.05)}
+.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_172630_e3c45b12-cb11-4065-93eb-3e487e59a556.png') center/cover no-repeat,linear-gradient(160deg,#f6e7d6,#eed2b8 55%,#e3c0a2);filter:saturate(1.2) brightness(1.06) contrast(1.03)}
 .ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 45%,rgba(227,163,156,.18) 0%,transparent 60%)}
 .ba-before-label,.ba-after-label{position:absolute;bottom:1.6rem;font-family:var(--font-body);font-size:.58rem;letter-spacing:.28em;text-transform:uppercase;font-weight:500;z-index:5;background:rgba(255,253,249,.85);padding:.45rem .95rem;border-radius:999px;backdrop-filter:blur(4px)}
 .ba-before-label{left:1.6rem;color:var(--text-secondary)}
@@ -132,15 +140,19 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 /* ===== CTA ===== */
 .section-cta{justify-content:center;text-align:center;padding:0 5vw}
 .cta-inner{display:flex;flex-direction:column;align-items:center;gap:1.5rem}
-.cta-button{display:inline-flex;align-items:center;gap:.8rem;font-family:var(--font-body);font-size:.7rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;color:#1a140e;background:linear-gradient(135deg,#a88a54,#c9a96e);padding:1.1rem 3rem;border:none;cursor:pointer;text-decoration:none;border-radius:6px;box-shadow:0 0 28px rgba(168,138,84,.3);transition:box-shadow .3s,transform .25s}
-.cta-button:hover{box-shadow:0 0 40px rgba(168,138,84,.5);transform:scale(1.03)}
-.cta-button svg{width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none}
+.cta-button{position:relative;overflow:hidden;display:inline-flex;align-items:center;gap:.8rem;font-family:var(--font-body);font-size:.7rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;color:var(--ink);background:var(--gold);padding:1.1rem 3rem;border:none;cursor:pointer;text-decoration:none;border-radius:6px;box-shadow:0 10px 30px -10px rgba(201,169,110,.5);transition:box-shadow .35s,transform .25s}
+.cta-button::before{content:'';position:absolute;inset:0;background:var(--gold-light);transform:scaleX(0);transform-origin:0 50%;transition:transform .45s cubic-bezier(.22,1,.36,1);z-index:0}
+.cta-button:hover::before{transform:scaleX(1)}
+.cta-button:hover{box-shadow:0 16px 40px -10px rgba(201,169,110,.65);transform:translateY(-2px)}
+.cta-button span,.cta-button svg{position:relative;z-index:1}
+.cta-button svg{position:relative;z-index:1;width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none;transition:transform .35s cubic-bezier(.22,1,.36,1)}
+.cta-button:hover svg{transform:translateX(4px)}
 .cta-sub{font-size:.65rem;letter-spacing:.2em;color:var(--text-muted);font-weight:200;text-transform:uppercase}
 
 /* ===== FLOATING BOOK BUTTON ===== */
-#float-boka{position:fixed;bottom:max(2.5rem,env(safe-area-inset-bottom));right:2.5rem;z-index:90;background:linear-gradient(135deg,#a88a54,#c9a96e);color:#1a140e;font-family:var(--font-body);font-size:.65rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;padding:.85rem 1.8rem;border:none;cursor:pointer;border-radius:6px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 4px 24px rgba(168,138,84,.35)}
+#float-boka{position:fixed;bottom:max(2.5rem,env(safe-area-inset-bottom));right:2.5rem;z-index:90;background:linear-gradient(135deg,var(--gold-dk),var(--gold-light));color:var(--ink);font-family:var(--font-body);font-size:.65rem;font-weight:600;letter-spacing:.25em;text-transform:uppercase;padding:.85rem 1.8rem;border:none;cursor:pointer;border-radius:6px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 8px 28px -6px rgba(201,169,110,.45)}
 #float-boka.visible{opacity:1;transform:translateY(0);pointer-events:auto}
-#float-boka:hover{box-shadow:0 4px 32px rgba(168,138,84,.55);transform:scale(1.04)}
+#float-boka:hover{box-shadow:0 12px 38px -6px rgba(201,169,110,.65);transform:translateY(-2px) scale(1.03)}
 
 /* ===== BOOKING MODAL ===== */
 .modal-overlay{position:fixed;inset:0;z-index:500;background:rgba(58,44,36,.45);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:center;opacity:0;visibility:hidden;transition:all .4s ease;padding:1rem}
@@ -159,8 +171,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .form-field select{background-color:#fffdf9;cursor:pointer}
 .form-field input:focus,.form-field select:focus,.form-field textarea:focus{border-color:rgba(201,169,110,.5)}
 .form-field textarea{resize:vertical;min-height:90px}
-.form-submit{background:linear-gradient(135deg,#a88a54,#c9a96e);color:#1a140e;font-family:var(--font-body);font-size:.7rem;letter-spacing:.25em;text-transform:uppercase;font-weight:600;padding:1rem 2rem;border:none;cursor:pointer;border-radius:6px;box-shadow:0 0 20px rgba(168,138,84,.3);transition:box-shadow .3s,transform .2s;margin-top:.5rem;width:100%}
-.form-submit:hover{box-shadow:0 0 32px rgba(168,138,84,.5);transform:scale(1.02)}
+.form-submit{background:linear-gradient(135deg,var(--gold-dk),var(--gold-light));color:var(--ink);font-family:var(--font-body);font-size:.7rem;letter-spacing:.25em;text-transform:uppercase;font-weight:600;padding:1rem 2rem;border:none;cursor:pointer;border-radius:6px;box-shadow:0 8px 24px -8px rgba(201,169,110,.45);transition:box-shadow .3s,transform .2s;margin-top:.5rem;width:100%}
+.form-submit:hover{box-shadow:0 12px 34px -8px rgba(201,169,110,.6);transform:translateY(-2px)}
 .modal-success{text-align:center;padding:2rem 0;display:none}
 .modal-success.visible{display:block}
 .success-icon{font-size:2.5rem;color:var(--gold-light);margin-bottom:1rem}
@@ -169,8 +181,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 /* ===== VISUAL ELEMENTS ===== */
 .floating-circle{position:fixed;border-radius:50%;pointer-events:none;z-index:2;opacity:0;will-change:transform}
-.floating-circle.c1{width:clamp(300px,40vw,600px);height:clamp(300px,40vw,600px);background:radial-gradient(circle,rgba(227,163,156,.16) 0%,transparent 70%);top:20%;right:-10%}
-.floating-circle.c2{width:clamp(200px,30vw,450px);height:clamp(200px,30vw,450px);background:radial-gradient(circle,rgba(202,162,92,.13) 0%,transparent 70%);bottom:10%;left:-5%}
+.floating-circle.c1{width:clamp(300px,40vw,600px);height:clamp(300px,40vw,600px);background:radial-gradient(circle,rgba(227,163,156,.22) 0%,transparent 70%);top:20%;right:-10%}
+.floating-circle.c2{width:clamp(200px,30vw,450px);height:clamp(200px,30vw,450px);background:radial-gradient(circle,rgba(201,169,110,.18) 0%,transparent 70%);bottom:10%;left:-5%}
 
 /* ===== GRAIN ===== */
 .grain{position:fixed;inset:0;z-index:999;pointer-events:none;opacity:.035;mix-blend-mode:overlay;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");background-repeat:repeat;background-size:256px 256px}
@@ -243,7 +255,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   <div class="hero-content">
     <span class="hero-label">Stockholm · Estetisk Klinik</span>
     <h1 class="hero-heading">
-      <span class="word">Vackrare.</span><br>
+      <span class="word accent">Vackrare.</span><br>
       <span class="word">Utan att</span> <span class="word">det syns.</span>
     </h1>
     <p class="hero-tagline">Legitimerade specialister · 8 års erfarenhet · 4 900+ nöjda patienter</p>
@@ -364,7 +376,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
       <span class="section-label">Nästa steg</span>
       <h2 class="section-heading" style="font-size:clamp(2.5rem,6vw,6rem)">Dags att<br>ta steget.</h2>
       <button class="cta-button" onclick="openModal()">
-        Boka gratis samtal
+        <span>Boka gratis samtal</span>
         <svg viewBox="0 0 24 24"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
       </button>
       <span class="cta-sub">Gratis · 15 minuter · Ingen bindning</span>
@@ -428,7 +440,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   function drawAmbient(p){
     const w=window.innerWidth,h=window.innerHeight;
     ctx.setTransform(dpr,0,0,dpr,0,0);
-    ctx.fillStyle="#FBF6EF"; ctx.fillRect(0,0,w,h);
+    ctx.fillStyle="#FCFAF5"; ctx.fillRect(0,0,w,h);
     const ox=w*(0.3+Math.sin(p*Math.PI*2)*0.2), oy=h*(0.35+Math.cos(p*Math.PI*1.5)*0.15), or=Math.min(w,h)*(0.3+p*0.15);
     const g1=ctx.createRadialGradient(ox,oy,0,ox,oy,or);
     g1.addColorStop(0,"rgba(227,163,156,0.18)"); g1.addColorStop(.5,"rgba(202,162,92,0.10)"); g1.addColorStop(1,"transparent");
@@ -440,8 +452,8 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
     const sy=h*(0.3+p*0.4), sg=ctx.createLinearGradient(0,sy,w,sy);
     sg.addColorStop(0,"transparent"); sg.addColorStop(.3,"rgba(202,162,92,0.05)"); sg.addColorStop(.7,"rgba(202,162,92,0.05)"); sg.addColorStop(1,"transparent");
     ctx.fillStyle=sg; ctx.fillRect(0,sy-100,w,200);
-    const vg=ctx.createRadialGradient(w/2,h/2,Math.min(w,h)*0.2,w/2,h/2,Math.max(w,h)*0.7);
-    vg.addColorStop(0,"transparent"); vg.addColorStop(1,"rgba(180,150,120,0.10)");
+    const vg=ctx.createRadialGradient(w/2,h/2,Math.min(w,h)*0.25,w/2,h/2,Math.max(w,h)*0.75);
+    vg.addColorStop(0,"transparent"); vg.addColorStop(1,"rgba(201,169,110,0.05)");
     ctx.fillStyle=vg; ctx.fillRect(0,0,w,h);
   }
 
@@ -574,9 +586,9 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
       onUpdate:self=>{
         const p=self.progress,e=0.56,l=0.74,fr=0.04;
         let o=0;
-        if(p>=e-fr&&p<=e)o=((p-(e-fr))/fr)*0.5;
-        else if(p>e&&p<l)o=0.5;
-        else if(p>=l&&p<=l+fr)o=0.5*(1-(p-l)/fr);
+        if(p>=e-fr&&p<=e)o=((p-(e-fr))/fr)*0.26;
+        else if(p>e&&p<l)o=0.26;
+        else if(p>=l&&p<=l+fr)o=0.26*(1-(p-l)/fr);
         overlay.style.opacity=o;
       }
     });


### PR DESCRIPTION
## Problem
- bahkobyra.cloud kändes för mörk och matchade inte bahkobyra.se
- Före/efter-bilden syntes inte (gammal/utgången CloudFront-URL)

## Palett → matchar bahkobyra.se
- Rubriker/ink från grumlig brun (`#3a2c24`) → navy ink (`#181C38`)
- Guld till sajtens värden (`#C9A96E` / `#E3C88E` / `#B08F4D`)
- Texttoner ombaserade på navy; ljusare cream-bakgrund (`#FCFAF5`)

## Ljusare
- Canvas-bakgrund + mjukare, guldtonad vinjett
- Fokus-veil över stats sänkt 0.5 → 0.26 (mörknar inte längre)
- Ljusare glöd-orbar

## Magi / lyft
- Hero-ordet "Vackrare." får animerad guld-gradient med shimmer
- Nav-länkar får guld-underline vid hover; guld-hairline på scrollad header
- CTA / float / formulärknappar → sajtens guld med sweep + lyft
- `::selection` i guld

## Fix: före/efter-bild
Den gamla CloudFront-URL:en var död. Genererade ett nytt porträtt (samma fungerande CDN som hero) och lade en gradient-fallback under så panelen aldrig blir tom.

https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7)_