### PR TITLE
Demo: riktig före/efter för hudföryngring (två olika bilder)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,12 @@
 {
   "permissions": {
     "allow": [
-      "Bash(winget install:*)"
+      "Bash(winget install:*)",
+      "mcp__a17450d2-4ea5-48c4-873e-2ce7e13cfe42__list_teams",
+      "mcp__a17450d2-4ea5-48c4-873e-2ce7e13cfe42__list_projects",
+      "mcp__a17450d2-4ea5-48c4-873e-2ce7e13cfe42__get_project",
+      "mcp__a17450d2-4ea5-48c4-873e-2ce7e13cfe42__get_deployment",
+      "mcp__a17450d2-4ea5-48c4-873e-2ce7e13cfe42__web_fetch_vercel_url"
     ]
   }
 }

--- a/bahkobyra/cloud/index.html
+++ b/bahkobyra/cloud/index.html
@@ -109,10 +109,10 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .ba-container{position:relative;width:min(700px,80vw);aspect-ratio:3/4;border-radius:4px;overflow:hidden;cursor:ew-resize}
 .ba-side{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-size:clamp(1.5rem,3vw,3rem);font-weight:300}
 .ba-before{z-index:1}
-.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_172630_e3c45b12-cb11-4065-93eb-3e487e59a556.png') center/cover no-repeat,linear-gradient(160deg,#f0ddc9,#e6c9b0 55%,#d3b196);filter:grayscale(.55) brightness(.92) contrast(.96)}
+.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_175336_0c90d13e-7b13-4d15-83a2-103b2fe0d247.jpeg') center/cover no-repeat,linear-gradient(160deg,#f0ddc9,#e6c9b0 55%,#d3b196);filter:grayscale(.18) brightness(.95) contrast(.98)}
 .ba-before::after{content:'';position:absolute;inset:0;background:rgba(58,44,36,.14)}
 .ba-after{clip-path:inset(0 100% 0 0);z-index:2}
-.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_172630_e3c45b12-cb11-4065-93eb-3e487e59a556.png') center/cover no-repeat,linear-gradient(160deg,#f6e7d6,#eed2b8 55%,#e3c0a2);filter:saturate(1.2) brightness(1.06) contrast(1.03)}
+.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_175414_19e0ded6-db4c-4a70-b773-3bef424f774f.png') center/cover no-repeat,linear-gradient(160deg,#f6e7d6,#eed2b8 55%,#e3c0a2);filter:saturate(1.06) brightness(1.03)}
 .ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 45%,rgba(227,163,156,.18) 0%,transparent 60%)}
 .ba-before-label,.ba-after-label{position:absolute;bottom:1.6rem;font-family:var(--font-body);font-size:.58rem;letter-spacing:.28em;text-transform:uppercase;font-weight:500;z-index:5;background:rgba(255,253,249,.85);padding:.45rem .95rem;border-radius:999px;backdrop-filter:blur(4px)}
 .ba-before-label{left:1.6rem;color:var(--text-secondary)}
@@ -294,7 +294,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   <section class="scroll-section section-beforeafter" data-enter="26" data-leave="42" data-animation="fade-up">
     <div style="position:relative">
       <div class="ba-heading">
-        <span class="section-label">002 / Resultat</span>
+        <span class="section-label">002 / Resultat · Hudföryngring PRX-T33</span>
         <h2 class="section-heading">Ser bra ut.<br>Känns som du.</h2>
       </div>
       <div class="ba-container" id="ba-container">

--- a/kliniker/elara-klinik-demo-v2.html
+++ b/kliniker/elara-klinik-demo-v2.html
@@ -109,10 +109,10 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 .ba-container{position:relative;width:min(700px,80vw);aspect-ratio:3/4;border-radius:4px;overflow:hidden;cursor:ew-resize}
 .ba-side{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-size:clamp(1.5rem,3vw,3rem);font-weight:300}
 .ba-before{z-index:1}
-.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_172630_e3c45b12-cb11-4065-93eb-3e487e59a556.png') center/cover no-repeat,linear-gradient(160deg,#f0ddc9,#e6c9b0 55%,#d3b196);filter:grayscale(.55) brightness(.92) contrast(.96)}
+.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_175336_0c90d13e-7b13-4d15-83a2-103b2fe0d247.jpeg') center/cover no-repeat,linear-gradient(160deg,#f0ddc9,#e6c9b0 55%,#d3b196);filter:grayscale(.18) brightness(.95) contrast(.98)}
 .ba-before::after{content:'';position:absolute;inset:0;background:rgba(58,44,36,.14)}
 .ba-after{clip-path:inset(0 100% 0 0);z-index:2}
-.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_172630_e3c45b12-cb11-4065-93eb-3e487e59a556.png') center/cover no-repeat,linear-gradient(160deg,#f6e7d6,#eed2b8 55%,#e3c0a2);filter:saturate(1.2) brightness(1.06) contrast(1.03)}
+.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_175414_19e0ded6-db4c-4a70-b773-3bef424f774f.png') center/cover no-repeat,linear-gradient(160deg,#f6e7d6,#eed2b8 55%,#e3c0a2);filter:saturate(1.06) brightness(1.03)}
 .ba-after::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 50% 45%,rgba(227,163,156,.18) 0%,transparent 60%)}
 .ba-before-label,.ba-after-label{position:absolute;bottom:1.6rem;font-family:var(--font-body);font-size:.58rem;letter-spacing:.28em;text-transform:uppercase;font-weight:500;z-index:5;background:rgba(255,253,249,.85);padding:.45rem .95rem;border-radius:999px;backdrop-filter:blur(4px)}
 .ba-before-label{left:1.6rem;color:var(--text-secondary)}
@@ -294,7 +294,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   <section class="scroll-section section-beforeafter" data-enter="26" data-leave="42" data-animation="fade-up">
     <div style="position:relative">
       <div class="ba-heading">
-        <span class="section-label">002 / Resultat</span>
+        <span class="section-label">002 / Resultat · Hudföryngring PRX-T33</span>
         <h2 class="section-heading">Ser bra ut.<br>Känns som du.</h2>
       </div>
       <div class="ba-container" id="ba-container">


### PR DESCRIPTION
## Problem
Före/efter-slidern använde samma bild med bara CSS-filter — ingen verklig förändring syntes.

## Lösning
Nu två genuint olika porträtt av samma kvinna:
- **Före:** matt, trött, ojämn hud
- **Efter:** strålande, jämn, glowig hud (genererad från före-bilden för identisk identitet/pose)

Filtren är dämpade så att den faktiska bildskillnaden syns, och sektionen är märkt med tjänsten (**Hudföryngring PRX-T33**) så det är tydligt vilket resultat som visas. Synkad i både den serverade kopian (`bahkobyra/cloud/index.html`) och `kliniker/elara-klinik-demo-v2.html`.

https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7)_