### PR TITLE
Positionering: offert = hemsidor överallt, växa-på-Google endast på bahkobyra.se

### DIFF
--- a/.claude/skills/instagram-engine/SKILL.md
+++ b/.claude/skills/instagram-engine/SKILL.md
@@ -8,7 +8,8 @@ disable-model-invocation: false
 # Instagram-motor (bygg & hantverk)
 
 Producerar content-batchar för **@bahkostudio** som driver top of funnel för bygg/hantverk-nischen.
-Mål: DM-konversationer → gratis Google/GBP-audit → sälj hemsida (engångsköp).
+Mål: DM-konversationer → gratis hemsideförslag (utkast) → sälj hemsida (engångsköp).
+**Offerten = hemsidor. "Växa på Google"-copy hör ENDAST hemma på bahkobyra.se — aldrig i reels/DM.**
 
 Full SOP: `workflows/instagram_engine.md`. Metodik/formler: `workflows/sales_methodology.md`.
 Allt operativt (cadence, skript, content-kalender) speglas i dashboarden:
@@ -24,7 +25,7 @@ Allt operativt (cadence, skript, content-kalender) speglas i dashboarden:
 2. **Hämta vinklar** ur `templates.md` (hooks/carouseller/DM per trade).
 3. **Generera batchen:**
    - **3 reel-script** enligt formeln: Hook → Problem → Agitera → Diskvalificera andra lösningar →
-     Lösning → CTA → Future pacing. CTA = gratis Google-audit ("DM:a 'GOOGLE'").
+     Lösning → CTA → Future pacing. CTA = gratis hemsideförslag ("DM:a 'SAJT'").
    - **2 carousell-outlines** (6–8 slides: hook-slide → värde → bevis → CTA-slide).
    - **Story-idéer** (poll, BTS, audit-CTA).
    - **DM-cadence** (skriven-first dag 1/3/5/7, se `workflows/outreach_cadence.md`).

--- a/.claude/skills/instagram-engine/templates.md
+++ b/.claude/skills/instagram-engine/templates.md
@@ -1,55 +1,56 @@
 # Instagram-mallbibliotek (bygg & hantverk)
 
 Råmaterial för skillen `instagram-engine`. Allt speglas i dashboardens **Instagram-motor**-sektion.
-Ton: svensk, rakt, lokalt, ingen corporate-svenska. CTA alltid → gratis Google-audit.
+Ton: svensk, rakt, lokalt, ingen corporate-svenska. **Offerten = hemsidor.** CTA alltid → gratis
+hemsideförslag (utkast). "Växa på Google"-copy hör ENDAST hemma på bahkobyra.se — aldrig här.
 
 ## Reel-formel
 
 Hook → Problem → Agitera → Diskvalificera andra lösningar → Lösning → CTA → Future pacing.
 Längd 15–35 s. Text-on-screen + tal. Stoppa scrollen på sekund 1.
 
-### Reel-hooks per trade
+### Reel-hooks per trade (sajt-fokus)
 
 **Bygg & renovering**
-- "Ditt byggföretag tappar offerter varje vecka — och det är inte din skull."
-- "Googla 'byggfirma [din stad]'. Om du inte är i topp 3 är det här därför."
-- "Snickare med fullbokad kalender gör EN sak online som du inte gör."
+- "Din sajt får ditt byggföretag att se ut som ett 2010-företag. Kunden märker det."
+- "Kunden kollar din hemsida innan de ringer. Vad ser de?"
+- "Du bygger fantastiska hus — men din sajt säljer inte ett enda jobb."
 
 **Tak (takläggare)**
-- "Takjobb går till firman som syns först på Google — inte den bästa."
-- "3 saker på din Google-profil som gör att taklägget får dina jobb."
-- "Du lägger tak. Din konkurrent lägger tid på Google. Gissa vem som ringer mest."
+- "Takjobb är dyra. Ingen lägger 80 000 kr efter att ha sett en trasig hemsida."
+- "Din konkurrent vann taklägget på sin sajt — inte på sitt hantverk."
+- "3 saker på din sajt som gör att takjobben går till någon annan."
 
 **Måleri**
-- "Målare: din hemsida säljer inte ett enda jobb. Här är varför."
-- "Folk googlar 'målare [stad]' kl 21. Syns du inte = du förlorar jobbet."
-- "En målare i [stad] dubblade förfrågningarna med en sak. Inte fler annonser."
+- "Folk kollar din sajt kl 21 innan de ringer. Vad möter dem?"
+- "En målare i [stad] dubblade förfrågningarna — med en ny hemsida, inte fler annonser."
+- "Din sajt säger inte ens vad du målar eller var. Det kostar jobb."
 
 **Mark & anläggning**
-- "Markjobb är high-ticket. Och du är osynlig där kunderna letar."
-- "Stenläggning, dränering, mark — alla googlar först. Rankar du?"
-- "Ditt anläggningsföretag förtjänar fler jobb än din webb ger dig."
+- "Markjobb är high-ticket — din sajt måste se ut därefter. Gör den det?"
+- "Stenläggning, dränering, mark — kunden bedömer dig på sajten först."
+- "Ditt anläggningsföretag förtjänar fler jobb än din webb drar in."
 
 ## Carousell-strukturer (6–8 slides)
 
-1. **"3 saker som gör att din sajt tappar jobb"** — slide 1 hook → 3 problem+fix → bevis → CTA-slide.
-2. **"Så hamnar [trade] i topp 3 på Google"** — 3 pelare (profil/sajt/citations) förenklat → CTA.
-3. **Före/efter** — gammal sajt vs ny → resultat (fler förfrågningar) → CTA.
-4. **"Vad kostar en osynlig sajt dig?"** — räkna förlorade jobb i kr/mån → CTA.
+1. **"3 saker som gör att din [trade]-sajt tappar jobb"** — hook → 3 problem+fix (CTA-knapp, mobil, bilder) → bevis → CTA.
+2. **"Så ser en sajt ut som drar in jobb"** — tydlig CTA → mobil först → bilder/recensioner → CTA.
+3. **Före/efter** — gammal sajt vs ny → resultat (fler offertförfrågningar) → CTA.
+4. **"Vad kostar en dålig sajt dig?"** — räkna förlorade jobb i kr/mån → CTA.
 
-Sista sliden alltid: "DM:a **GOOGLE** så gör jag en gratis koll på din profil."
+Sista sliden alltid: "DM:a **SAJT** så skickar jag ett gratis utkast på er nya hemsida."
 
 ## Bild-/citatkort
 
-- "Bästa hantverkaren vinner inte. Den som syns vinner."
-- "0 minuter på Google = oändligt mindre än konkurrenten som la 20."
-- Resultat-kort: "[Trade] i [stad]: +X förfrågningar på 60 dagar."
+- "Bästa hantverkaren vinner inte. Den som ser ut som proffset vinner."
+- "Kunden bedömer ditt hantverk på din hemsida — innan de ens ringt."
+- Resultat-kort: "[Trade] i [stad]: +X offertförfrågningar efter ny sajt."
 
-## DM-cadence (skriven-first)
+## DM-cadence (skriven-first, sajt-fokus)
 
-- **Dag 1:** "Hej {{namn}}! Gillar verkligen jobben ni gör 🙌 Snabb fråga — sköter någon er Google-profil?"
-- **Dag 3:** "Körde en snabb koll på er profil och såg ett par saker som påverkar er ranking lokalt. Vill du ha en 2-min-video som visar hur jag fixar dem?"
-- **Dag 5:** "Hann du kika? Tar 2 min och kostar inget — bara konkreta nästa steg för fler jobb via Google."
-- **Dag 7:** "Sista pingen från mig 🙂 Om fler jobb via Google inte är prio just nu säg bara till, annars skickar jag videon."
+- **Dag 1:** "Hej [Namn]! Riktigt snyggt jobb på [specifikt projekt ni postat] 🙌 Snabb fråga — vem byggde er hemsida?"
+- **Dag 3:** "Kikade på er sajt och såg ett par saker som nog kostar er jobb (t.ex. svårt att få offert via mobilen). Vill du att jag skickar en 2-min video med ett utkast på hur den kan se ut?"
+- **Dag 5:** "Hann du kika? Kostar inget — bara ett konkret förslag på en sajt som drar in fler offertförfrågningar."
+- **Dag 7:** "Sista pingen 🙂 Om en ny sajt inte är prio nu säg bara till."
 
-Svar → boka samtal → gratis audit (Loom) → sälj hemsida (engångs). Se `workflows/outreach_cadence.md`.
+Svar → boka samtal → gratis utkast (Loom) → sälj hemsida (engångs). Se `workflows/outreach_cadence.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,14 +81,20 @@ Fundamentet för all försäljning. Full playbook: `workflows/sales_methodology.
 Källdokument i `reference/`. **Allt operativt körs från dashboarden:** `bahkobyra/dashboard/index.html`
 (CRM med cadence, offert-väljare, outreach-skript, Instagram-motor, Spelbok).
 
-**Offer-stegen (ett varumärke, två budskap):**
+**POSITIONERING (viktigt):**
+- **Offerten = hemsidor.** På ALLA kanaler (Instagram, cold email/call/IRL, DM) säljer vi hemsidor som front offer.
+- **"Växa på Google"-copy ENDAST på `www.bahkobyra.se`.** Aldrig i outreach, DM, reels eller dashboard-skript.
+- Local SEO / Google-ranking är intern leverans (klinik-retainer) — inte säljbudskapet.
+
+**Offer-stegen (ett varumärke, två nischer):**
 
 | | Klinik (cold email/call/IRL) | Bygg & hantverk (Instagram @bahkostudio) |
 |--|------------------------------|-------------------------------------------|
-| Front (gratis) | Gratis Google/GBP-audit | Gratis Google/GBP-audit |
-| Core (betalt) | Hemsida + retainer (35 000 kr + 9 000 kr/mån) | Hemsida engångs (29 900 kr) |
+| Front (gratis) | Gratis hemsideförslag (2-min Loom + utkast) | Gratis hemsideförslag (utkast) |
+| Core (betalt) | Hemsida + löpande optimering (35 000 kr + 9 000 kr/mån) | Hemsida engångs (29 900 kr) |
 
 - **Offer-regel:** resultat + mekanism + riskreversering + villkor. FOR THEM / REAL / Financial Sense / Easy YES.
+- **Outreach-copy:** kort, personlig, mänsklig, hjälpsam. En konkret observation om DERAS sajt + en tydlig CTA.
 - **Front-offer = bevisa "the wizard"**, inte tjäna pengar. Sen uppsell.
 - **Cadence:** välj EN väg/lead (skriven/samtal/IRL), dag 1/3/5/7 → svar=boka, tyst=nurture/stäng.
 - **Daglig blast:** volym slår allt. Flaskhals = bokade möten/vecka.

--- a/bahkobyra/dashboard/index.html
+++ b/bahkobyra/dashboard/index.html
@@ -422,7 +422,7 @@ footer{margin-top:3.5rem;padding:1.5rem var(--gut);text-align:center;font-size:.
 
   <!-- OFFERTFÖRSLAG -->
   <section class="sec" id="offert">
-    <div class="sec-h">Offertförslag <span class="hint">välj nisch · front = gratis Google-audit · copy-paste redo</span></div>
+    <div class="sec-h">Offertförslag <span class="hint">välj nisch · offert = hemsida · copy-paste redo</span></div>
     <div class="seg" id="offer-seg" style="margin-bottom:1.1rem">
       <button data-niche="klinik" class="on">Klinik</button>
       <button data-niche="bygg">Bygg &amp; hantverk</button>
@@ -437,7 +437,7 @@ footer{margin-top:3.5rem;padding:1.5rem var(--gut);text-align:center;font-size:.
       <div class="op-card">
         <div class="op-num">02</div>
         <div class="op-title">Real</div>
-        <div class="op-body">Specifika siffror, konkret bevis. Visa audit-videon. Referera till demo-kliniken. Vaga löften dödar förtroende — exakta observationer bygger det.</div>
+        <div class="op-body">Specifika siffror, konkret bevis. Visa 2-min-videon med utkastet. Referera till demon. Vaga löften dödar förtroende — exakta observationer om deras sajt bygger det.</div>
       </div>
       <div class="op-card">
         <div class="op-num">03</div>
@@ -481,7 +481,7 @@ footer{margin-top:3.5rem;padding:1.5rem var(--gut);text-align:center;font-size:.
         <div class="oc-box">
           <div class="oc-lbl">Erbjudandet håller om alla 5 stämmer ✓</div>
           <div class="oc-row"><span class="oc-dot"></span>Du pratar om deras resultat — inte din teknik</div>
-          <div class="oc-row"><span class="oc-dot"></span>Du har en specifik audit eller demo att referera till</div>
+          <div class="oc-row"><span class="oc-dot"></span>Du har en specifik sajt-genomgång eller demo att referera till</div>
           <div class="oc-row"><span class="oc-dot"></span>Du har räknat värdet i kr/mån med dem live</div>
           <div class="oc-row"><span class="oc-dot"></span>Du har nämnt garantin aktivt</div>
           <div class="oc-row"><span class="oc-dot"></span>Du har gett 2 betalningsval — inte fler, inte färre</div>
@@ -497,97 +497,111 @@ footer{margin-top:3.5rem;padding:1.5rem var(--gut);text-align:center;font-size:.
     <div class="scripts">
 
       <div class="script">
-        <div class="script-h"><span class="nm">Kallt mejl</span><span class="tag">E-post</span><button class="copy">Kopiera</button></div>
-        <pre>Ämne: 3 saker på [Klinik]s sajt som kostar bokningar
+        <div class="script-h"><span class="nm">Kallt mejl (klinik)</span><span class="tag">E-post</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: [Klinik]s hemsida
 
-Hej [Namn], jag driver Bahko Byrå — vi hjälper kliniker få fler patientbokningar via sajt + Google. Spelade in en 3-min gratis-audit av er sajt (värde 799 kr): [Loom-länk]. Vill ni se exakt hur ni kan få fler bokningar? Boka en kvart: https://cal.eu/bahkobyra/15min
+Hej [Namn],
+
+hittade [Klinik] när jag kollade [behandling] i [stad] — [äkta detalj, t.ex. "era före/efter-bilder är riktigt fina"].
+
+Märkte en sak på er sajt: [konkret observation — t.ex. "ingen bokningsknapp högst upp" / "laddar trögt i mobilen"]. Sånt kostar bokningar.
+
+Jag bygger hemsidor åt kliniker som gör besökare till bokningar. Spelade in en 2-min video med exakt vad jag skulle ändra — vill du att jag skickar den?
 
 /Mathias, Bahko Byrå</pre>
       </div>
 
       <div class="script">
-        <div class="script-h"><span class="nm">Instagram DM</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
-        <pre>Hej! Gillar verkligen det ni gör på [Klinik] 🙌 Jag hjälper kliniker få fler bokningar via sajt + Google och gjorde en snabb gratis-analys av er sajt — vill du att jag skickar den?</pre>
+        <div class="script-h"><span class="nm">Instagram DM (klinik)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
+        <pre>Hej [Namn]! Följde precis [Klinik] — [äkta komplimang om ett specifikt inlägg/resultat] 🙌
+
+Snabb grej: jag bygger hemsidor åt kliniker och såg ett par saker på er sajt som nog kostar er bokningar. Vill du att jag skickar en kort video på hur jag hade fixat det?</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">LinkedIn — kontaktförfrågan</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn]! Jag såg att ni driver [Klinik] och imponerades av er profil. Jag hjälper kliniker att ranka bättre på Google och konvertera fler besökare till bokningar — vill gärna koppla ihop oss!</pre>
+        <pre>Hej [Namn]! Såg att du driver [Klinik] i [stad]. Jag bygger hemsidor åt kliniker som vill att fler besökare faktiskt bokar — kopplar gärna ihop oss.</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">LinkedIn DM (efter accept)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
-        <pre>Tack för att du accepterade [Namn]! Jag kollade er sajt och spelade in en kort 3-min genomgång med konkreta förbättringar — gratis, värde 799 kr. Vill du att jag skickar den? [Loom-länk]</pre>
+        <pre>Tack [Namn]! Kikade på [Klinik]s sajt och fastnade på en sak: [1 konkret observation]. Jag bygger om sajter så att besökare bokar istället för att studsa vidare. Spelade in en 2-min video med exakt vad jag skulle ändra — vill du ha den?</pre>
       </div>
 
       <div class="script">
-        <div class="script-h"><span class="nm">Loom-genomgång</span><span class="tag">Video</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn]! Jag kollade på [Klinik]s sajt och spelade in en snabb 3-min genomgång — hittade 3 saker som troligen kostar er bokningar. Byggde också ett snabbt exempel på hur en ny sida kan se ut för er. [Loom-länk]. Ser det intressant ut — boka en kvart: https://cal.eu/bahkobyra/15min</pre>
+        <div class="script-h"><span class="nm">Loom-genomgång (front)</span><span class="tag">Video</span><button class="copy">Kopiera</button></div>
+        <pre>Hej [Namn]! Kollade [Klinik]s sajt och spelade in 2 min — 3 saker som troligen kostar er bokningar:
+
+1) [konkret — t.ex. svårt att boka i mobilen]
+2) [konkret — t.ex. ingen tydlig CTA högst upp]
+3) [konkret — t.ex. inga riktiga bilder/resultat]
+
+Byggde också ett snabbt utkast på hur en ny startsida kan se ut för er. [Loom-länk]. Gillar du riktningen — boka en kvart: https://cal.eu/bahkobyra/15min</pre>
       </div>
 
       <div class="script">
-        <div class="script-h"><span class="nm">Telefon — cold call</span><span class="tag">Telefon</span><button class="copy">Kopiera</button></div>
-        <pre>Hej, jag heter Mathias och ringer från Bahko Byrå. Vi specialiserar oss på att hjälpa kliniker som [Klinik] att få fler bokningar via Google och er sajt. Jag har faktiskt tittat på er hemsida och har ett par konkreta förbättringsidéer — tar det 2 minuter att berätta?
+        <div class="script-h"><span class="nm">Telefon — cold call (klinik)</span><span class="tag">Telefon</span><button class="copy">Kopiera</button></div>
+        <pre>Hej, det är Mathias från Bahko Byrå. Ringer för att jag tittade på [Klinik]s hemsida och såg ett par saker som nog kostar er bokningar — jag bygger om sånt så att fler besökare faktiskt bokar. Tar det 30 sekunder att berätta varför jag ringer?
 
-[Om ja] Bra! Jag kan skicka en gratis video-audit — 3 minuter, konkreta tips. Vilket är bästa e-posten?
+[Om ja] Kort: [1 konkret observation]. Jag kan spela in en 2-min video som visar exakt vad jag skulle ändra — vad är bästa mejlen?
 
-[Om nej/upptagen] Inga problem! Kan jag skicka en kort mejl istället? Vad är er e-postadress?</pre>
+[Om nej/upptagen] Inga problem — skickar en kort rad istället. Bästa mejlen?</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Uppföljning 1 (dag +3)</span><span class="tag">Follow-up</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn], hann du kika på audit-videon jag skickade? Snabb sammanfattning: [1 konkret grej]. Värt en kort koll? https://cal.eu/bahkobyra/15min</pre>
+        <pre>Hej [Namn], hann du kika på videon? Kortversionen: [1 konkret sak] hade gett er fler bokningar direkt. Vill du att jag bygger ett gratis utkast på er nya startsida?</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Uppföljning 2 (dag +6)</span><span class="tag">Follow-up</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn], sista pingen från mig — om bokningar via sajten inte är prio just nu säg bara till så släpper jag. Annars: https://cal.eu/bahkobyra/15min. Ha det fint!</pre>
+        <pre>Hej [Namn], sista pingen från mig 🙂 Om en ny hemsida inte är prio just nu säg bara till så släpper jag. Annars skickar jag gärna utkastet: https://cal.eu/bahkobyra/15min</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Discovery call (20 min)</span><span class="tag">Möte</span><button class="copy">Kopiera</button></div>
-        <pre>1. Nuläge & mål — var är ni nu, vart vill ni? (5 min)
-2. Vad problemet kostar idag — bokningar/jobb via sajt vs. telefon? (3 min)
-3. Visa demo + audit — konkret exempel (Élara-kliniken / demo-sajt) (5 min)
-4. Erbjudande + pris + risk-vändare — garanti (4 min)
-5. Stäng / boka nästa steg — offert eller pilotprojekt? (3 min)</pre>
+        <pre>1. Nuläge & mål — hur får ni kunder idag, vart vill ni? (5 min)
+2. Vad sajten kostar er idag — hur många besökare bokar/hör av sig? (3 min)
+3. Visa demo + utkast — konkret exempel (Élara-demon / utkast på deras sajt) (5 min)
+4. Erbjudande + pris + garanti (4 min)
+5. Stäng / nästa steg — offert eller pilot? (3 min)</pre>
       </div>
 
       <div class="script">
-        <div class="script-h"><span class="nm">Gratis Google-audit (Loom)</span><span class="tag">Front-offer</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn], jag märkte 3 saker på er Google Business Profile som troligen skadar er ranking:
+        <div class="script-h"><span class="nm">Gratis hemsideförslag (Loom)</span><span class="tag">Front-offer</span><button class="copy">Kopiera</button></div>
+        <pre>Hej [Namn], kollade [företag]s sajt och spelade in 2 min — 3 saker som troligen kostar er [bokningar/jobb]:
 
-ETT: ni saknar [t.ex. kategorier/tjänster] — alla i topp-3 har det.
-TVÅ: [fel hemsida länkad / NAP inte konsekvent].
-TRE: ni har bara [X] bilder — topp-3 har minst 30.
+ETT: [konkret — t.ex. ingen tydlig väg till bokning/offert].
+TVÅ: [konkret — t.ex. ser inte bra ut i mobilen].
+TRE: [konkret — t.ex. inga bilder på era jobb/resultat].
 
-Jag hittade 5 saker till. Vill bjuda in dig till ett 15-min-möte där jag visar dem + mitt erbjudande att fixa allt. Värsta fall: du går därifrån med konkreta nästa steg. Bästa fall: vi fixar det åt er.
+Byggde ett snabbt utkast på hur en ny startsida kan se ut. Vill bjuda in dig till 15 min där jag visar det + förslag att bygga om allt. Värsta fall: du går därifrån med konkreta idéer. Bästa fall: vi bygger en sajt som drar in [bokningar/jobb].
 Boka: https://cal.eu/bahkobyra/15min</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Cadence · Samtal-first</span><span class="tag">Telefon</span><button class="copy">Kopiera</button></div>
-        <pre>DAG 1: Samtal #1 + recap-mejl ("kul att prata — här är gratis-auditen [Loom]")
-DAG 3: Samtal #2 (hann du kika? ett par konkreta grejer till)
-DAG 5: Samtal #3 (sista uppringningen — värt en kvart?)
+        <pre>DAG 1: Samtal #1 + recap-mejl ("kul att prata — här är 2-min-videon med utkastet [Loom]")
+DAG 3: Samtal #2 (hann du kika på utkastet? ett par idéer till)
+DAG 5: Samtal #3 (sista uppringningen — värt en kvart att gå igenom?)
 DAG 7: Close-loop-mejl ("stänger ärendet om timing inte stämmer — hör av dig när det passar")
 → Svar = boka möte. Inget svar dag 7 = nurture (+30 dagar).</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Cadence · IRL-first</span><span class="tag">IRL</span><button class="copy">Kopiera</button></div>
-        <pre>DAG 1: Besök #1 — "Hej, jag jobbar med [kliniker/hantverkare] här i [stad] med Google + hemsidor. Sköter någon er Google-profil?"
-DAG 2: Uppföljning — skicka gratis-auditen (Loom) till mejlen du fick.
-DAG 5: Samtal (om direktnummer) — "hann du kika på videon?"
+        <pre>DAG 1: Besök #1 — "Hej, jag bygger hemsidor åt [kliniker/hantverkare] här i [stad]. Kikade snabbt på er sajt — får jag visa en sak?"
+DAG 2: Uppföljning — skicka 2-min-videon med utkastet till mejlen du fick.
+DAG 5: Samtal (om direktnummer) — "hann du kika på utkastet?"
 → Svar = boka möte. Annars nurture.</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Instagram DM-cadence (bygg)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
-        <pre>DAG 1: Hej [Namn]! Gillar verkligen jobben ni gör 🙌 Snabb fråga — sköter någon er Google-profil?
-DAG 3: Körde en snabb koll på er profil och såg ett par saker som påverkar er ranking lokalt. Vill du ha en 2-min-video som visar hur jag fixar dem?
-DAG 5: Hann du kika? Tar 2 min och kostar inget — bara konkreta nästa steg för fler jobb via Google.
-DAG 7: Sista pingen från mig 🙂 Om fler jobb via Google inte är prio just nu säg bara till.</pre>
+        <pre>DAG 1: Hej [Namn]! Riktigt snyggt jobb på [specifikt projekt ni postat] 🙌 Snabb fråga — vem byggde er hemsida?
+DAG 3: Kikade på er sajt och såg ett par saker som nog kostar er jobb (t.ex. svårt att få offert via mobilen). Vill du att jag skickar en 2-min video med ett utkast på hur den kan se ut?
+DAG 5: Hann du kika? Kostar inget — bara ett konkret förslag på en sajt som drar in fler offertförfrågningar.
+DAG 7: Sista pingen 🙂 Om en ny sajt inte är prio nu säg bara till.</pre>
       </div>
 
     </div>
@@ -600,36 +614,36 @@ DAG 7: Sista pingen från mig 🙂 Om fler jobb via Google inte är prio just nu
     <div class="cards" style="margin-bottom:1rem">
       <div class="card"><div class="t"><span class="ic">🎬</span> 3 reels/vecka</div><div class="d">Hook → problem → agitera → lösning → CTA. Stoppa scrollen sekund 1.</div><div class="meta">Räckvidd</div></div>
       <div class="card"><div class="t"><span class="ic">🗂️</span> 2 carouseller/vecka</div><div class="d">Utbilda &amp; bevisa expertis. 6–8 slides, spara/dela-magnet.</div><div class="meta">Auktoritet</div></div>
-      <div class="card"><div class="t"><span class="ic">📲</span> Daglig story</div><div class="d">Top-of-mind: polls, BTS, audit-CTA ("DM:a GOOGLE").</div><div class="meta">Närvaro</div></div>
-      <div class="card"><div class="t"><span class="ic">🎯</span> Front-offer</div><div class="d">Varje CTA → gratis Google/GBP-audit → sälj hemsida (engångs).</div><div class="meta">Konvertering</div></div>
+      <div class="card"><div class="t"><span class="ic">📲</span> Daglig story</div><div class="d">Top-of-mind: polls, BTS från bygget, sajt-CTA ("DM:a SAJT").</div><div class="meta">Närvaro</div></div>
+      <div class="card"><div class="t"><span class="ic">🎯</span> Front-offer</div><div class="d">Varje CTA → gratis hemsideförslag (utkast) → sälj hemsida (engångs).</div><div class="meta">Konvertering</div></div>
     </div>
 
     <div class="scripts">
       <div class="script">
         <div class="script-h"><span class="nm">Reel-formel</span><span class="tag">Mall</span><button class="copy">Kopiera</button></div>
-        <pre>HOOK (0–2s): "[Trade] tappar jobb varje vecka — och det är inte din skull."
-PROBLEM: kunder googlar "[trade] [stad]" — syns du inte är du borta.
-AGITERA: varje vecka osynlig = förlorade offerter till sämre konkurrenter.
-DISKVALIFICERA: fler annonser löser det inte. Inte heller en "snyggare" sajt.
-LÖSNING: en sajt som rankar + komplett Google-profil = du dyker upp först.
-CTA: "DM:a GOOGLE så gör jag en gratis koll på din profil."
-FUTURE PACING: "Om 60 dagar ringer telefonen för att DU syns först."</pre>
+        <pre>HOOK (0–2s): "Din [trade]-sajt tappar jobb varje vecka — och du märker det inte."
+PROBLEM: kunden kollar din sajt innan de ringer — ser den gammal/krånglig ut, går de vidare.
+AGITERA: varje besökare som studsar = en offertförfrågan rakt till konkurrenten.
+DISKVALIFICERA: fler annonser fyller en läckande hink. Sajten måste konvertera först.
+LÖSNING: en sajt byggd för att få besökaren att begära offert — tydlig, snabb, mobilanpassad.
+CTA: "DM:a SAJT så skickar jag ett gratis utkast på hur er nya hemsida kan se ut."
+FUTURE PACING: "Om 30 dagar kommer offertförfrågningarna in via sajten — inte bara via tips."</pre>
       </div>
       <div class="script">
         <div class="script-h"><span class="nm">Carousell-outline</span><span class="tag">Mall</span><button class="copy">Kopiera</button></div>
         <pre>Slide 1 (hook): "3 saker som gör att din [trade]-sajt tappar jobb"
-Slide 2: #1 Du syns inte på Google Maps → fix
-Slide 3: #2 Sajten säger inte vad du gör / var → fix
-Slide 4: #3 Inga recensioner/bilder → fix
-Slide 5 (bevis): före/efter eller resultat-siffra
-Slide 6 (CTA): "DM:a GOOGLE för gratis koll på din profil"</pre>
+Slide 2: #1 Ingen tydlig väg till offert (knapp/formulär) → fix
+Slide 3: #2 Ser dålig ut i mobilen — där 8 av 10 tittar → fix
+Slide 4: #3 Inga bilder på era jobb + recensioner → fix
+Slide 5 (bevis): före/efter av en sajt + resultat (fler förfrågningar)
+Slide 6 (CTA): "DM:a SAJT för ett gratis utkast på er nya hemsida"</pre>
       </div>
       <div class="script">
         <div class="script-h"><span class="nm">Trade-hooks</span><span class="tag">Idéer</span><button class="copy">Kopiera</button></div>
-        <pre>BYGG: "Googla 'byggfirma [stad]'. Inte i topp 3? Här är därför."
-TAK: "Takjobb går till firman som syns först — inte den bästa."
-MÅLERI: "Folk googlar 'målare [stad]' kl 21. Syns du inte = du förlorar jobbet."
-MARK: "Markjobb är high-ticket. Och du är osynlig där kunderna letar."
+        <pre>BYGG: "Din sajt får ditt byggföretag att se ut som ett 2010-företag. Kunden märker det."
+TAK: "Takjobb är dyra. Ingen lägger ner 80 000 kr efter att ha sett en trasig hemsida."
+MÅLERI: "Folk kollar din sajt kl 21 innan de ringer. Vad ser de?"
+MARK: "Markjobb är high-ticket — din sajt måste se ut därefter. Gör den det?"
 
 Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller + DM-cadence).</pre>
       </div>
@@ -652,11 +666,11 @@ Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller +
     <div class="sec-h">Spelbok — BIAB-metodiken <span class="hint">offer-stegen · cadence · leverans · invändningar</span></div>
 
     <div class="ladder" style="margin-bottom:1rem">
-      <div class="rung"><div class="st">Front (gratis)</div><div class="ti">Gratis Google-audit</div><div class="de">Enda jobbet: bevisa att du är "the wizard". Loom som visar 3 brister + 5 till på mötet.</div></div>
+      <div class="rung"><div class="st">Front (gratis)</div><div class="ti">Gratis hemsideförslag</div><div class="de">Enda jobbet: bevisa att du är "the wizard". 2-min Loom som visar 3 brister + ett utkast på ny startsida.</div></div>
       <div class="arr">→</div>
-      <div class="rung"><div class="st">Core (betalt)</div><div class="ti">Hemsida som säljer</div><div class="de">Klinik: hemsida + Local SEO-retainer (9 000 kr/mån). Bygg: hemsida som engångsköp.</div></div>
+      <div class="rung"><div class="st">Core (betalt)</div><div class="ti">Hemsida som säljer</div><div class="de">Klinik: hemsida + löpande optimering (9 000 kr/mån). Bygg: hemsida som engångsköp.</div></div>
       <div class="arr">→</div>
-      <div class="rung"><div class="st">Uppsell</div><div class="ti">Mer wizardry</div><div class="de">När du bevisat magi: Google Ads, Meta Ads, fler sidor. Continuity gör dig rik.</div></div>
+      <div class="rung"><div class="st">Uppsell</div><div class="ti">Mer wizardry</div><div class="de">När du bevisat magi: fler sidor, annonser, innehåll, underhåll. Continuity gör dig rik.</div></div>
     </div>
 
     <div class="play-card" style="margin-bottom:1rem">
@@ -674,17 +688,17 @@ Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller +
 
     <div class="play-grid">
       <div class="play-card">
-        <h4><span class="ic">📈</span> Local SEO — 3 pelare</h4>
+        <h4><span class="ic">📈</span> En sajt som säljer</h4>
         <ul>
-          <li><strong>GBP:</strong> 1 huvudkategori, full profil, ~30 tjänster, bilder + posts varje vecka.</li>
-          <li><strong>On-page:</strong> title (BÄSTA + kategori + stad), H1/H2, NAP i footer, inbäddad karta, ~30 sidor.</li>
-          <li><strong>Citations:</strong> Bing, Apple, Foursquare, Yelp + branschkataloger som rankar. Konsekvent NAP.</li>
+          <li><strong>Tydlig CTA:</strong> boka/begär offert högst upp + på varje skärm. Ingen jakt.</li>
+          <li><strong>Mobil först:</strong> snabb, lättläst, en-tums-tumme-navigering — 8 av 10 tittar i mobilen.</li>
+          <li><strong>Förtroende:</strong> riktiga bilder på jobb/resultat, recensioner, tydligt vad ni gör & var.</li>
         </ul>
       </div>
       <div class="play-card">
         <h4><span class="ic">🧭</span> Sälj-logistik</h4>
         <ul>
-          <li>Intresse → <strong>Loom</strong>-audit → boka <strong>samtal</strong> → mejl med summering + betallänk → onboarding.</li>
+          <li>Intresse → <strong>Loom</strong> (utkast) → boka <strong>samtal</strong> → mejl med summering + betallänk → onboarding.</li>
           <li>Offer = resultat + mekanism + <strong>riskreversering</strong> + villkor. Aldrig en tjänstebeskrivning.</li>
           <li>Texting = logistik ("när ses vi?"). Korta, mänskliga, hjälpsamma meddelanden.</li>
         </ul>
@@ -713,7 +727,7 @@ Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller +
     <div class="sec-h">Daglig checklista <span class="hint">nollställs automatiskt varje dag</span></div>
     <div class="check" id="check">
       <div class="check-row" data-id="c1"><span class="check-box"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></span><span class="lbl">Bygg 20 nya kvalade prospekts (klinik + bygg) i CRM</span></div>
-      <div class="check-row" data-id="c2"><span class="check-box"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></span><span class="lbl">Skicka 20 personliga outreach (Loom/audit)</span></div>
+      <div class="check-row" data-id="c2"><span class="check-box"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></span><span class="lbl">Skicka 20 personliga outreach (Loom/utkast)</span></div>
       <div class="check-row" data-id="c3"><span class="check-box"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></span><span class="lbl">Kör alla i "Dagens uppföljningar" (logga touch)</span></div>
       <div class="check-row" data-id="c4"><span class="check-box"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></span><span class="lbl">Logga varje touch + uppdatera pipeline i CRM</span></div>
       <div class="check-row" data-id="c5"><span class="check-box"><svg viewBox="0 0 12 12"><polyline points="2,6 5,9 10,3"/></svg></span><span class="lbl">Bekräfta &amp; förbered dagens discovery calls</span></div>
@@ -1066,8 +1080,8 @@ const OFFERS={
     price:'35 000 kr + 9 000 kr/mån',
     terms:'alt. 0 kr upfront + 14 000 kr/mån · 3 mån bindning · start inom 7 dagar',
     rows:[
-      ['them','For Them','Mätbart fler patientbokningar via Google och er sajt — inte bara en snyggare hemsida'],
-      ['real','Real','Konverterande hemsida + top-3 lokalt på Google + patientbokningsoptimering (täpper läckorna i bokningsflödet)'],
+      ['them','For Them','Mätbart fler patientbokningar via en hemsida byggd för att konvertera — inte bara en snyggare sajt'],
+      ['real','Real','Konverterande hemsida + patientbokningsoptimering som täpper varje läcka i bokningsflödet'],
       ['fin','$ Sense','6 extra bokningar/mån à 1 500 kr täcker hela retainern — allt däröver är ren vinst'],
       ['easy','Easy Yes','90-dagarsgaranti: inga mätbara resultat → vi jobbar gratis tills det händer']
     ],
@@ -1075,9 +1089,9 @@ const OFFERS={
 
 Vad ni får:
 • Konverterande hemsida byggd för att generera bokningar (inte bara se bra ut)
-• Lokal SEO — top-3 på Google i er stad för era behandlingar
 • Patientbokningsoptimering — vi täpper varje läcka i bokningsflödet
-• Löpande uppföljning och optimering varje månad
+• Löpande optimering, innehåll och uppdateringar varje månad
+• Veckovis rapportering så ni ser vad som händer
 
 Vad det kostar:
 Alt 1: 35 000 kr (engång) + 9 000 kr/mån
@@ -1098,21 +1112,21 @@ mathias@bahkobyra.se`,
     roi:{mode:'retainer',retainer:9000,valLabel:'Genomsnittsvärde per bokning (kr)',bkLabel:'Extra bokningar/mån (realistisk prognos)',val:1500,bk:10}
   },
   bygg:{
-    title:'Bygg <em>Tillväxt</em>',
+    title:'Hemsida som <em>säljer</em>',
     price:'29 900 kr (engång)',
-    terms:'konverterande hemsida + komplett Google-profil · ingen bindning · start inom 7 dagar',
+    terms:'konverterande hemsida som drar in jobb · ingen bindning · start inom 7 dagar',
     rows:[
-      ['them','For Them','Fler jobb och offertförfrågningar via en sajt som rankar — inte bara en snyggare webb'],
-      ['real','Real','Konverterande hemsida + komplett Google Business Profile så ni dyker upp först lokalt'],
+      ['them','For Them','Fler jobb och offertförfrågningar via en hemsida som konverterar — inte bara en snyggare webb'],
+      ['real','Real','Konverterande hemsida, mobilanpassad och snabb, med tydliga offert-CTA:n'],
       ['fin','$ Sense','Ett enda extra jobb i månaden betalar sajten flera gånger om — high-ticket-bransch'],
-      ['easy','Easy Yes','Fast pris, ingen bindning, gratis Google-audit först så ni ser exakt vad ni får']
+      ['easy','Easy Yes','Fast pris, ingen bindning, gratis förslag/mockup först så ni ser exakt vad ni får']
     ],
     tpl:`OFFERT: Hemsida som säljer — Bahko Byrå
 
 Vad ni får:
 • Konverterande hemsida byggd för att dra in jobb (inte bara se bra ut)
-• Komplett Google Business Profile så ni rankar lokalt
 • Mobilanpassat, snabbt, med tydliga offert-CTA:n
+• Galleri på era bästa jobb + recensioner som bygger förtroende
 • Allt klart och live inom överenskommen tid
 
 Vad det kostar:
@@ -1120,9 +1134,9 @@ Vad det kostar:
 
 Vad det ger er:
 Ett enda extra jobb i månaden betalar sajten många gånger om.
-Ni syns först där kunderna letar — och konverterar besökare till offertförfrågningar.
+Besökare blir offertförfrågningar — istället för att studsa vidare till konkurrenten.
 
-Nästa steg: boka 20 min så går vi igenom er gratis Google-audit.
+Nästa steg: boka 20 min så går vi igenom ert gratis hemsideförslag.
 https://cal.eu/bahkobyra/15min
 
 /Mathias, Bahko Byrå

--- a/content/vaxa-pa-google-3-tips.md
+++ b/content/vaxa-pa-google-3-tips.md
@@ -1,0 +1,59 @@
+# Manus: 3 tips för att växa på Google
+
+**Var:** bahkobyra.se — levereras när någon registrerar sig (gratis-guide / välkomstvideo + mejl).
+**Källa:** `workflows/local_seo_delivery.md` (80/20 av Local SEO-SOP:n).
+**Ton:** varm, expert men enkel. Ca 75–90 sek som video, funkar även som text.
+**Regel:** "Växa på Google"-copy hör bara hemma här — på bahkobyra.se.
+
+---
+
+## VIDEO-MANUS (talspråk)
+
+**HOOK**
+Hej, det är Mathias från Bahko Byrå. Tack för att du laddade ner guiden.
+Här är sanningen ingen säger till dig: de flesta lokala företag tror att Google rankar
+den *bästa* verksamheten högst upp. Det gör den inte. Den rankar den som gjort *läxan*.
+Och läxan tar typ en eftermiddag. Här är de tre viktigaste sakerna.
+
+**TIPS 1 — Fyll din Google-företagsprofil till 100%**
+Det första Google tittar på är hur komplett din företagsprofil är.
+Rätt huvudkategori, alla dina tjänster utlagda, riktiga bilder, öppettider, telefon, länk till sajten.
+De flesta lämnar den halvfärdig — och undrar varför de ligger på sida två.
+Gå in på din profil idag och gör varje fält ifyllt. Completeness är det Google belönar,
+för det ger besökaren en bättre upplevelse.
+
+**TIPS 2 — Få ett jämnt flöde av recensioner**
+Recensioner är en av de starkaste rankingfaktorerna — och det som får en ny kund att välja dig.
+Knepet är inte att samla 200 på en gång. Det är att be *varje* nöjd kund, *varje* vecka.
+Gör det till en rutin: efter varje lyckat besök, skicka länken. Ett jämnt flöde slår en engångspuckel.
+
+**TIPS 3 — Samma uppgifter överallt + visa att du lever**
+Sista biten: ditt namn, din adress och ditt telefonnummer ska se *exakt* likadana ut
+på din sajt, din Google-profil och i kataloger. Google litar på dig när allt stämmer överens.
+Och posta något litet varje vecka — en bild, en uppdatering. Det signalerar att verksamheten är aktiv.
+
+**CTA**
+Gör de här tre sakerna så kommer du att klättra. Vill du hellre att vi gör det åt dig —
+och bygger en hemsida som faktiskt omvandlar besökarna till bokningar — boka ett kort samtal,
+så går vi igenom just din situation. Länken finns under videon. Vi ses där.
+
+---
+
+## E-POST-VERSION (välkomstmejl efter registrering)
+
+**Ämne:** Dina 3 tips för att synas högre på Google
+
+Hej [Förnamn],
+
+tack för att du laddade ner guiden! Här är kortversionen — tre saker du kan göra denna vecka:
+
+1. **Fyll Google-företagsprofilen till 100%** — rätt kategori, alla tjänster, riktiga bilder, öppettider.
+   Completeness är det Google belönar.
+2. **Be om recensioner varje vecka** — fråga varje nöjd kund. Ett jämnt flöde slår en engångspuckel.
+3. **Samma namn/adress/telefon överallt + posta varje vecka** — konsekvens bygger förtroende hos
+   Google, och regelbundna inlägg visar att ni är aktiva.
+
+Vill du att vi tar hand om det åt dig — och bygger en hemsida som omvandlar besökarna till bokningar?
+[Boka ett kort samtal →](https://cal.eu/bahkobyra/15min)
+
+/Mathias, Bahko Byrå

--- a/workflows/instagram_engine.md
+++ b/workflows/instagram_engine.md
@@ -1,7 +1,8 @@
 # Workflow: Instagram-motor (bygg & hantverk)
 
 Top-of-funnel-motorn för bygg/hantverk-nischen. Postar från **@bahkostudio**. Säljer hemsidor
-(engångsköp) med gratis Google/GBP-audit som front-offer. Drivs av skillen `instagram-engine`.
+(engångsköp) med gratis hemsideförslag (utkast) som front-offer. Drivs av skillen `instagram-engine`.
+**OBS:** offerten = hemsidor. "Växa på Google"-copy hör ENDAST hemma på bahkobyra.se, aldrig i reels/DM.
 
 ## Objektiv
 
@@ -33,7 +34,7 @@ Varje reel/ad: **Hook → Problem → Agitera → Diskvalificera andra lösninga
 Idé-generering: gå runt och bestäm "jag gör en reel innan jag går hem". Fråga: "om jag drev ett
 [takföretag] och ville ha fler jobb — vad skulle jag undra över?"
 
-CTA leder alltid till front-offern: **gratis Google/GBP-audit** ("DM:a 'GOOGLE' så kollar jag din profil").
+CTA leder alltid till front-offern: **gratis hemsideförslag** ("DM:a 'SAJT' så skickar jag ett utkast på er nya hemsida").
 
 ---
 

--- a/workflows/local_seo_delivery.md
+++ b/workflows/local_seo_delivery.md
@@ -1,7 +1,9 @@
-# Workflow: Local SEO / GBP-leverans
+# Workflow: Local SEO / GBP-leverans (INTERN)
 
-Hur vi faktiskt levererar "Växa på Google" efter att en kund sagt ja. Distillerat från
-`reference/Local_SEO_Workflow.pdf` + `reference/BM_Challenge.pdf`. Detta är service-delivery-SOP:n.
+Hur vi faktiskt levererar "Växa på Google" — som **intern leverans** (klinik-retainer) och som underlag
+för **bahkobyra.se:s** växa-på-google-copy/lead magnet. Distillerat från `reference/Local_SEO_Workflow.pdf`
++ `reference/BM_Challenge.pdf`. **OBS:** detta är leverans/copy för bahkobyra.se — INTE outreach-säljbudskapet.
+Front-offern i outreach/DM = hemsidor (se `workflows/sales_methodology.md`).
 
 ## Objektiv
 
@@ -92,6 +94,7 @@ Veckovis uppdatering till kund varje update-dag. Be kund om: (1) löpande recens
 
 ## Koppling till verktyg
 
-- `tools/generate_audit.js --type=gbp` — producerar GBP-auditen vi använder som front-offer/Loom-underlag.
-- Front-offer levereras via `bahkobyra/kliniker/gratis-granskning.html`.
+- `tools/generate_audit.js --type=gbp` — producerar GBP-auditen vi använder som leverans-underlag (klinik-retainer)
+  och för bahkobyra.se:s växa-på-google-innehåll.
+- bahkobyra.se:s lead magnet (gratis granskning/guide) bor i `bahkobyra/kliniker/`.
 - Sälj-/offer-logik: `workflows/sales_methodology.md`. Cadence: `workflows/outreach_cadence.md`.

--- a/workflows/sales_methodology.md
+++ b/workflows/sales_methodology.md
@@ -35,7 +35,7 @@ Vill du att jag skickar en kort video som visar exakt hur?"
 
 > Front-offerns enda jobb är att etablera dig som "the wizard" — INTE att tjäna pengar.
 
-- Du gör något undeniable billigt/gratis (gratis Google/GBP-audit). Du bevisar magi.
+- Du gör något undeniable billigt/gratis (gratis hemsideförslag / 2-min Loom + utkast). Du bevisar magi.
 - När de sett att du levererar vill de behålla dig **till varje pris**. Wizards får betalt.
 - Sen säljer du allt: hemsida, retainer, Google Ads, Meta Ads.
 - **Continuity (retainer) > engångsköp.** Du börjar varje månad på "inte noll".
@@ -44,7 +44,9 @@ Vill du att jag skickar en kort video som visar exakt hur?"
   det vi har, 2) vi fortsätter klättra. Därför ett månadspaket. Plus: vi jobbar inte med en konkurrent i
   din zon så länge vi samarbetar." (Håll radien rimlig.)
 
-**BahkoByras front-offer = gratis Google/GBP-audit (Loom).** Levereras via `bahkobyra/kliniker/gratis-granskning.html`.
+**BahkoByras offer = hemsidor.** Front-offer på ALLA kanaler = gratis hemsideförslag (2-min Loom som visar
+3 brister på deras sajt + ett utkast på ny startsida). **"Växa på Google"-copy ENDAST på `www.bahkobyra.se`** —
+aldrig i outreach/DM/reels. Local SEO/Google-ranking = intern leverans (klinik-retainer), inte säljbudskap.
 
 ---
 


### PR DESCRIPTION
## Vad som ändrades

Efter feedback: **offerten = hemsidor på alla kanaler**, och **"Växa på Google"-copy endast på bahkobyra.se**. Plus en finslipning av all outreach-copy enligt SOP.

### Outreach-copy omskriven (SOP-stil)
- Mejl, IG DM, LinkedIn ×2, Loom, cold call, uppföljningar, alla 3 cadence-vägar, IG DM-cadence
- Kort, personlig, mänsklig — en konkret observation om **deras sajt** + en tydlig CTA
- Säljer **endast hemsidor** (2-min video + gratis utkast som front-offer)

### Dashboard rensad från Google/SEO-budskap
- Offert-sektion: "Klinik Tillväxt" (hemsida + löpande optimering) / "Hemsida som säljer" (bygg, engångs)
- Instagram-motor: reel-formel, carousell, trade-hooks, CTA → hemsida ("DM:a SAJT")
- Spelbok: offer-stege + "En sajt som säljer" istället för Local SEO-copy
- Google/GBP/Local SEO = intern leverans (klinik-retainer), inte säljbudskap

### Memory + content
- CLAUDE.md, workflows och instagram-engine: positioneringsregel inskriven
- `content/vaxa-pa-google-3-tips.md` — manus (video + mejl) för bahkobyra.se-registreringar

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbpzazkwW1wCEyyhK9qCR7)_