### PR TITLE
CEO-genomgång: kundvänd polering, e-postflöden + enkel hero-bild

### DIFF
--- a/CEO_AUDIT.md
+++ b/CEO_AUDIT.md
@@ -1,0 +1,56 @@
+# CEO-genomgång — Bahko Byrå (juni 2026)
+
+Fullständig granskning av allt kundvänt: hemsida, landningssidor, demo, dashboard, CRM,
+e-postflöden och dev-miljö. Det som kunde fixas i repot är fixat. Det som kräver konton,
+inspelning eller beslut står under "Kräver dig" — i prioritetsordning.
+
+## Fixat i denna runda
+
+**Hemsidan (bahkobyra.se)**
+- Intern pipelinesiffra ("87+ Klinikleads Klara") visades för kunder → ersatt med kundlöftet "24h Svar På Gratis Analys"
+- Popupen återkom var 90:e sekund i all evighet → visas nu en gång, sedan tyst i 7 dagar (localStorage)
+- Nyhetsbrevsregistrering i footern (Formspree, ämnesrad "Ny prenumerant – nyhetsbrev") + länkar till Gratis Guide och Live Demo
+- Honeypot-spamskydd (`_gotcha`) på kontaktformuläret
+
+**Gratis analys-sidan**
+- "Inga strings attached" (svengelska) → "utan krav och utan säljpitch"
+- Formulärplaceholder var säljarens eget namn → neutralt exempel
+- Nytt valfritt kvalificeringsfält: "Er största utmaning just nu" (gör 24h-rapporten träffsäker direkt)
+- Succéläget levererar nu värde under väntetiden: länk till guiden
+- Open Graph-taggar (ser professionell ut vid delning) + honeypot
+
+**Gratis guide-sidan**
+- Upplåsningen sparas nu (localStorage) — registrerade besökare möts inte av låst guide vid återbesök
+- Honeypot
+
+**Demon (Élara)**
+- Sifferkonflikt: hero sa "4 900+ nöjda patienter", statistiken räknade till 4 200 → enhetligt 4 900+
+
+**Det som saknades helt — nu byggt**
+- `content/email/valkomstmejl-och-sekvens.md` — 5 färdiga mejl: välkomst (analys), välkomst (guide), dag 2, dag 5, dag 10 + setup-checklista för MailerLite/Brevo
+- `content/email/nyhetsbrev-2026-q3.md` — 3 färdigskrivna nyhetsbrev (juni/juli/augusti) + idébank
+- Dashboard: ny sektion **"E-post efter registrering & nyhetsbrev"** med alla mejl som kopieringskort — skicka manuellt samma dag tills automationen är live
+
+**Infrastruktur**
+- Dev-servern speglar nu Vercel (webbroot = `bahkobyra/`), loggen pekade på 4 döda sökvägar → korrekta
+- Sitemap-datum uppdaterade
+
+## Kräver dig (kan inte göras från repot)
+
+1. **HÖGST: Skicka välkomstmejlen manuellt från idag.** Varje formulärsvar i Formspree-inkorgen
+   ska få välkomstmejlet samma dag (kopieringskorten finns i dashboarden). Detta är skillnaden
+   mellan en lead som svalnar och ett bokat möte.
+2. **MailerLite/Brevo-konto + Formspree-webhook** — automatisera sekvensen (checklista i
+   `content/email/valkomstmejl-och-sekvens.md`). Verifiera SPF/DKIM för bahkobyra.se så mejlen
+   inte hamnar i skräppost.
+3. **Spela in guide-videon** — manus klart i `content/gratis-guide-video-manus.md`. Guiden visar
+   fortfarande en platshållare där videon ska vara. Ladda upp olistad (YouTube/Loom), klistra in
+   embed (sök `BYT UT` i `gratis-guide.html`).
+4. **GA4 + Search Console** — du flyger blint utan trafikdata. Steg-för-steg finns i
+   `dashboard/todo.html`. Skicka in sitemapen.
+5. **Socialt bevis** — sajten saknar riktiga resultat/testimonials. Be första nöjda kunden om
+   3 meningar + siffra. Tills dess: använd Élara-demon som bevis (det görs redan i skripten).
+6. **Schema-luckor i `index.html`** — fyll i `telephone` och `sameAs` (Instagram/LinkedIn) när
+   profilerna finns.
+7. **Google Business Profile för Bahko Byrå själv** — practice what you preach; det är dessutom
+   ert eget bästa säljbevis ("vi gjorde det här för oss själva på X veckor").

--- a/bahkobyra/cloud/index.html
+++ b/bahkobyra/cloud/index.html
@@ -346,7 +346,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
   <section class="scroll-section section-stats" data-enter="58" data-leave="72" data-animation="stagger-up">
     <div class="stats-grid">
       <div class="stat">
-        <div><span class="stat-number" data-value="4200" data-decimals="0">0</span></div>
+        <div><span class="stat-number" data-value="4900" data-decimals="0">0</span><span class="stat-suffix">+</span></div>
         <span class="stat-label">Nöjda patienter</span>
       </div>
       <div class="stat">

--- a/bahkobyra/css/style.css
+++ b/bahkobyra/css/style.css
@@ -282,6 +282,9 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
   letter-spacing:.14em;text-transform:uppercase;margin-top:2rem;transition:gap .3s}
 .demo-link:hover{gap:1.1rem}
 .demo-link svg{width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none}
+.demo-proof{margin-top:1.2rem;font-size:.8rem;color:var(--paper-45);font-weight:300}
+.demo-proof a{color:var(--gold-lt);border-bottom:1px solid rgba(201,169,110,.35);padding-bottom:1px;transition:color .3s,border-color .3s}
+.demo-proof a:hover{color:var(--gold);border-color:var(--gold)}
 
 /* ── 15. WHY ─────────────────────────────────────────────── */
 .why .wrap{display:grid;grid-template-columns:1fr 1.05fr;gap:clamp(2.5rem,6vw,6rem);align-items:start}

--- a/bahkobyra/css/style.css
+++ b/bahkobyra/css/style.css
@@ -349,6 +349,19 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
 .foot-brand em{font-style:italic;color:var(--gold-lt)}
 .foot-cta{text-align:right}
 .foot-cta p{color:var(--paper-70);font-size:.8rem;margin-bottom:1rem;letter-spacing:.04em}
+.foot-nl{max-width:var(--maxw);margin:2.4rem auto 0;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1.4rem 2.5rem;
+  padding:1.8rem 2rem;background:rgba(201,169,110,.06);border:1px solid var(--paper-line);border-radius:var(--r-lg)}
+.foot-nl-copy h4{font-family:var(--display);font-size:1.35rem;font-weight:500;margin-bottom:.3rem}
+.foot-nl-copy p{font-size:.78rem;color:var(--paper-70);font-weight:300;max-width:46ch;line-height:1.6}
+.foot-nl-form{display:flex;gap:.7rem;flex-wrap:wrap;position:relative}
+.foot-nl-form input[type="email"]{min-width:min(280px,70vw);background:rgba(245,242,235,.06);border:1px solid var(--paper-line);
+  color:var(--paper);font-family:var(--sans);font-size:.9rem;font-weight:300;padding:.85rem 1.1rem;border-radius:var(--r);outline:none;
+  transition:border-color .3s,background .3s;-webkit-appearance:none;appearance:none}
+.foot-nl-form input[type="email"]:focus{border-color:rgba(201,169,110,.55);background:rgba(245,242,235,.1)}
+.foot-nl-form input[type="email"]::placeholder{color:rgba(245,242,235,.28)}
+.foot-nl-ok{display:none;font-size:.84rem;color:var(--gold-lt)}
+.foot-nl.sent .foot-nl-form{display:none}
+.foot-nl.sent .foot-nl-ok{display:block}
 .foot-bottom{max-width:var(--maxw);margin:2rem auto 0;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
 .foot-bottom span{font-size:.64rem;letter-spacing:.14em;text-transform:uppercase;color:var(--paper-45)}
 .foot-links{display:flex;gap:1.6rem}

--- a/bahkobyra/dashboard/index.html
+++ b/bahkobyra/dashboard/index.html
@@ -308,7 +308,7 @@ footer{margin-top:3.5rem;padding:1.5rem var(--gut);text-align:center;font-size:.
       <div class="kpi">
         <div class="kpi-top"><span class="kpi-l">Mål · återkommande intäkt</span></div>
         <div class="kpi-v">100<small>k kr/mån</small></div>
-        <div class="goal" style="font-size:.66rem;color:var(--ink-35)">≈ 8 retainers × 12k — nästa: 300k → 1 Mkr</div>
+        <div class="goal" style="font-size:.66rem;color:var(--ink-35)">flaskhalsen är bokade möten/vecka — allt annat är sekundärt</div>
       </div>
     </div>
   </section>
@@ -517,7 +517,9 @@ hittade [Klinik] när jag kollade [behandling] i [stad] — [äkta detalj, t.ex.
 
 Märkte en sak på er sajt: [konkret observation — t.ex. "ingen bokningsknapp högst upp" / "laddar trögt i mobilen"]. Sånt kostar bokningar.
 
-Jag bygger hemsidor åt kliniker som gör besökare till bokningar. Spelade in en 2-min video med exakt vad jag skulle ändra — vill du att jag skickar den?
+Jag bygger hemsidor åt kliniker som gör besökare till bokningar. Vill du se hur er sajt skulle kunna se ut? Jag skickar ett klickbart exempel — gratis, utan krav.
+
+Senaste bygget: maykaskitchen.se
 
 /Mathias, Bahko Byrå</pre>
       </div>
@@ -526,7 +528,7 @@ Jag bygger hemsidor åt kliniker som gör besökare till bokningar. Spelade in e
         <div class="script-h"><span class="nm">Instagram DM (klinik)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
         <pre>Hej [Namn]! Följde precis [Klinik] — [äkta komplimang om ett specifikt inlägg/resultat] 🙌
 
-Snabb grej: jag bygger hemsidor åt kliniker och såg ett par saker på er sajt som nog kostar er bokningar. Vill du att jag skickar en kort video på hur jag hade fixat det?</pre>
+Snabb grej: jag bygger hemsidor åt kliniker och såg ett par saker på er sajt som nog kostar er bokningar. Vill du se hur en ny sajt kan se ut? Jag skickar ett klickbart exempel — gratis, utan krav.</pre>
       </div>
 
       <div class="script">
@@ -536,64 +538,71 @@ Snabb grej: jag bygger hemsidor åt kliniker och såg ett par saker på er sajt 
 
       <div class="script">
         <div class="script-h"><span class="nm">LinkedIn DM (efter accept)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
-        <pre>Tack [Namn]! Kikade på [Klinik]s sajt och fastnade på en sak: [1 konkret observation]. Jag bygger om sajter så att besökare bokar istället för att studsa vidare. Spelade in en 2-min video med exakt vad jag skulle ändra — vill du ha den?</pre>
+        <pre>Tack [Namn]! Kikade på [Klinik]s sajt och fastnade på en sak: [1 konkret observation]. Jag bygger om sajter så att besökare bokar istället för att studsa vidare. Vill du se ett klickbart exempel på hur er nya sajt kan se ut? Skickar länken — gratis.</pre>
       </div>
 
       <div class="script">
-        <div class="script-h"><span class="nm">Loom-genomgång (front)</span><span class="tag">Video</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn]! Kollade [Klinik]s sajt och spelade in 2 min — 3 saker som troligen kostar er bokningar:
+        <div class="script-h"><span class="nm">Vid svar → skicka demon</span><span class="tag">Front-offer</span><button class="copy">Kopiera</button></div>
+        <pre>Hej [Namn]! Kul att du svarade. Här är exemplet — en kliniksajt byggd för att göra besökare till bokningar:
 
-1) [konkret — t.ex. svårt att boka i mobilen]
-2) [konkret — t.ex. ingen tydlig CTA högst upp]
-3) [konkret — t.ex. inga riktiga bilder/resultat]
+→ Demo (klicka runt, funkar i mobilen): https://www.bahkobyra.cloud
+→ Senaste skarpa bygget: https://maykaskitchen.se
 
-Byggde också ett snabbt utkast på hur en ny startsida kan se ut för er. [Loom-länk]. Gillar du riktningen — boka en kvart: https://cal.eu/bahkobyra/15min</pre>
+Såhär skulle [Klinik] kunna se ut — design, bilder och innehåll anpassas helt efter er när vi bygger.
+
+Värt 15 minuter? Då går jag igenom exakt vad jag skulle göra för just er sajt:
+https://cal.eu/bahkobyra/15min</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Telefon — cold call (klinik)</span><span class="tag">Telefon</span><button class="copy">Kopiera</button></div>
         <pre>Hej, det är Mathias från Bahko Byrå. Ringer för att jag tittade på [Klinik]s hemsida och såg ett par saker som nog kostar er bokningar — jag bygger om sånt så att fler besökare faktiskt bokar. Tar det 30 sekunder att berätta varför jag ringer?
 
-[Om ja] Kort: [1 konkret observation]. Jag kan spela in en 2-min video som visar exakt vad jag skulle ändra — vad är bästa mejlen?
+[Om ja] Kort: [1 konkret observation]. Jag har ett klickbart exempel på hur en ny kliniksajt kan se ut — vad är bästa mejlen så skickar jag länken?
 
 [Om nej/upptagen] Inga problem — skickar en kort rad istället. Bästa mejlen?</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Uppföljning 1 (dag +3)</span><span class="tag">Follow-up</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn], hann du kika på videon? Kortversionen: [1 konkret sak] hade gett er fler bokningar direkt. Vill du att jag bygger ett gratis utkast på er nya startsida?</pre>
+        <pre>Hej [Namn], hann du klicka runt i demon? Kortversionen: [1 konkret sak] hade gett er fler bokningar direkt. Värt en kvart? Då visar jag exakt vad jag skulle göra för just er sajt: https://cal.eu/bahkobyra/15min</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Uppföljning 2 (dag +6)</span><span class="tag">Follow-up</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn], sista pingen från mig 🙂 Om en ny hemsida inte är prio just nu säg bara till så släpper jag. Annars skickar jag gärna utkastet: https://cal.eu/bahkobyra/15min</pre>
+        <pre>Hej [Namn], sista pingen från mig 🙂 Om en ny hemsida inte är prio just nu säg bara till så släpper jag. Annars — boka en kvart så visar jag hur er nya sajt kan se ut: https://cal.eu/bahkobyra/15min</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Discovery call (20 min)</span><span class="tag">Möte</span><button class="copy">Kopiera</button></div>
         <pre>1. Nuläge & mål — hur får ni kunder idag, vart vill ni? (5 min)
-2. Vad sajten kostar er idag — hur många besökare bokar/hör av sig? (3 min)
-3. Visa demo + utkast — konkret exempel (Élara-demon / utkast på deras sajt) (5 min)
-4. Erbjudande + pris + garanti (4 min)
-5. Stäng / nästa steg — offert eller pilot? (3 min)</pre>
+2. Vad sajten kostar er idag — hur många besökare bokar/hör av sig? (4 min)
+3. Demo-genomgång — Élara-demon + maykaskitchen.se, koppla till DERAS sajt (6 min)
+4. Behov → lösning — vad jag skulle bygga för just er (3 min)
+5. Nästa steg — "jag skickar ett skriftligt förslag idag" (2 min)
+
+OBS: Inget pris på mötet. Priset kommer ENDAST i den skriftliga offerten
+(offert-väljaren ovan) — skickas samma dag som mötet.</pre>
       </div>
 
       <div class="script">
-        <div class="script-h"><span class="nm">Gratis hemsideförslag (Loom)</span><span class="tag">Front-offer</span><button class="copy">Kopiera</button></div>
-        <pre>Hej [Namn], kollade [företag]s sajt och spelade in 2 min — 3 saker som troligen kostar er [bokningar/jobb]:
+        <div class="script-h"><span class="nm">Front-offer — gratis hemsideförslag</span><span class="tag">Front-offer</span><button class="copy">Kopiera</button></div>
+        <pre>Hej [Namn], kollade [företag]s sajt — 3 saker som troligen kostar er [bokningar/jobb]:
 
 ETT: [konkret — t.ex. ingen tydlig väg till bokning/offert].
 TVÅ: [konkret — t.ex. ser inte bra ut i mobilen].
 TRE: [konkret — t.ex. inga bilder på era jobb/resultat].
 
-Byggde ett snabbt utkast på hur en ny startsida kan se ut. Vill bjuda in dig till 15 min där jag visar det + förslag att bygga om allt. Värsta fall: du går därifrån med konkreta idéer. Bästa fall: vi bygger en sajt som drar in [bokningar/jobb].
-Boka: https://cal.eu/bahkobyra/15min</pre>
+Vill du se hur en ny sajt kan se ut? Jag skickar ett klickbart exempel — gratis, utan krav.
+Senaste bygget: maykaskitchen.se
+
+Värsta fall: du får konkreta idéer. Bästa fall: vi bygger en sajt som drar in [bokningar/jobb].</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Cadence · Samtal-first</span><span class="tag">Telefon</span><button class="copy">Kopiera</button></div>
-        <pre>DAG 1: Samtal #1 + recap-mejl ("kul att prata — här är 2-min-videon med utkastet [Loom]")
-DAG 3: Samtal #2 (hann du kika på utkastet? ett par idéer till)
+        <pre>DAG 1: Samtal #1 + recap-mejl ("kul att prata — här är demon: bahkobyra.cloud + senaste bygget maykaskitchen.se")
+DAG 3: Samtal #2 (hann du klicka runt i demon? ett par idéer till)
 DAG 5: Samtal #3 (sista uppringningen — värt en kvart att gå igenom?)
 DAG 7: Close-loop-mejl ("stänger ärendet om timing inte stämmer — hör av dig när det passar")
 → Svar = boka möte. Inget svar dag 7 = nurture (+30 dagar).</pre>
@@ -601,17 +610,17 @@ DAG 7: Close-loop-mejl ("stänger ärendet om timing inte stämmer — hör av d
 
       <div class="script">
         <div class="script-h"><span class="nm">Cadence · IRL-first</span><span class="tag">IRL</span><button class="copy">Kopiera</button></div>
-        <pre>DAG 1: Besök #1 — "Hej, jag bygger hemsidor åt [kliniker/hantverkare] här i [stad]. Kikade snabbt på er sajt — får jag visa en sak?"
-DAG 2: Uppföljning — skicka 2-min-videon med utkastet till mejlen du fick.
-DAG 5: Samtal (om direktnummer) — "hann du kika på utkastet?"
+        <pre>DAG 1: Besök #1 — "Hej, jag bygger hemsidor åt [kliniker/hantverkare] här i [stad]. Kikade snabbt på er sajt — får jag visa en sak?" (visa demon i mobilen)
+DAG 2: Uppföljning — skicka demo-länken till mejlen du fick.
+DAG 5: Samtal (om direktnummer) — "hann du klicka runt i demon?"
 → Svar = boka möte. Annars nurture.</pre>
       </div>
 
       <div class="script">
         <div class="script-h"><span class="nm">Instagram DM-cadence (bygg)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
         <pre>DAG 1: Hej [Namn]! Riktigt snyggt jobb på [specifikt projekt ni postat] 🙌 Snabb fråga — vem byggde er hemsida?
-DAG 3: Kikade på er sajt och såg ett par saker som nog kostar er jobb (t.ex. svårt att få offert via mobilen). Vill du att jag skickar en 2-min video med ett utkast på hur den kan se ut?
-DAG 5: Hann du kika? Kostar inget — bara ett konkret förslag på en sajt som drar in fler offertförfrågningar.
+DAG 3: Kikade på er sajt och såg ett par saker som nog kostar er jobb (t.ex. svårt att få offert via mobilen). Vill du se ett klickbart exempel på hur er nya sajt kan se ut? Gratis. (Senaste bygget: maykaskitchen.se)
+DAG 5: Hann du kika? Kostar inget — bara ett konkret exempel på en sajt som drar in fler offertförfrågningar.
 DAG 7: Sista pingen 🙂 Om en ny sajt inte är prio nu säg bara till.</pre>
       </div>
 
@@ -804,7 +813,7 @@ Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller +
     <div class="sec-h">Spelbok — BIAB-metodiken <span class="hint">offer-stegen · cadence · leverans · invändningar</span></div>
 
     <div class="ladder" style="margin-bottom:1rem">
-      <div class="rung"><div class="st">Front (gratis)</div><div class="ti">Gratis hemsideförslag</div><div class="de">Enda jobbet: bevisa att du är "the wizard". 2-min Loom som visar 3 brister + ett utkast på ny startsida.</div></div>
+      <div class="rung"><div class="st">Front (gratis)</div><div class="ti">Gratis hemsideförslag</div><div class="de">Enda jobbet: bevisa att du är "the wizard". 1 konkret observation om DERAS sajt + klickbart demo (bahkobyra.cloud) + skarpt bevis (maykaskitchen.se). Anpassas efter köp.</div></div>
       <div class="arr">→</div>
       <div class="rung"><div class="st">Core (betalt)</div><div class="ti">Hemsida som säljer</div><div class="de">Klinik: hemsida + löpande optimering (9 000 kr/mån). Bygg: hemsida som engångsköp.</div></div>
       <div class="arr">→</div>
@@ -836,7 +845,7 @@ Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller +
       <div class="play-card">
         <h4><span class="ic">🧭</span> Sälj-logistik</h4>
         <ul>
-          <li>Intresse → <strong>Loom</strong> (utkast) → boka <strong>samtal</strong> → mejl med summering + betallänk → onboarding.</li>
+          <li>Intresse → <strong>demo-länk</strong> → boka <strong>möte</strong> → skriftlig offert samma dag (pris ENDAST i offerten) → onboarding.</li>
           <li>Offer = resultat + mekanism + <strong>riskreversering</strong> + villkor. Aldrig en tjänstebeskrivning.</li>
           <li>Texting = logistik ("när ses vi?"). Korta, mänskliga, hjälpsamma meddelanden.</li>
         </ul>
@@ -1304,8 +1313,10 @@ Allt däröver är ren vinst — ni betalar inte för tid, ni betalar för resul
 Risk-vändare:
 Mätbart fler bokningar på 90 dagar — annars jobbar vi gratis tills det händer.
 
-Nästa steg: boka 20 min så visar jag exakt vad jag hittat på er sajt.
-https://cal.eu/bahkobyra/15min
+Se själv:
+Demo: https://www.bahkobyra.cloud · Senaste leverans: https://maykaskitchen.se
+
+Nästa steg: svara "kör igång" på det här mejlet så startar vi inom 7 dagar.
 
 /Mathias, Bahko Byrå
 mathias@bahkobyra.se`,
@@ -1336,8 +1347,11 @@ Vad det ger er:
 Ett enda extra jobb i månaden betalar sajten många gånger om.
 Besökare blir offertförfrågningar — istället för att studsa vidare till konkurrenten.
 
-Nästa steg: boka 20 min så går vi igenom ert gratis hemsideförslag.
-https://cal.eu/bahkobyra/15min
+Se själv:
+Senaste leverans: https://maykaskitchen.se
+
+Nästa steg: svara "kör igång" så startar vi inom 7 dagar.
+Eller boka 15 min om du vill gå igenom något först: https://cal.eu/bahkobyra/15min
 
 /Mathias, Bahko Byrå
 mathias@bahkobyra.se`,

--- a/bahkobyra/dashboard/index.html
+++ b/bahkobyra/dashboard/index.html
@@ -262,6 +262,7 @@ footer{margin-top:3.5rem;padding:1.5rem var(--gut);text-align:center;font-size:.
   <div class="top-actions">
     <a class="tbtn solid" href="https://cal.eu/bahkobyra/15min" target="_blank" rel="noopener">+ Boka möte</a>
     <a class="tbtn" href="#crm">CRM</a>
+    <a class="tbtn" href="#epost">E-post</a>
     <a class="tbtn" href="#ig">Instagram</a>
     <a class="tbtn" href="#spelbok">Spelbok</a>
     <a class="tbtn" href="/dashboard/todo.html">Roadmap</a>
@@ -615,6 +616,133 @@ DAG 7: Sista pingen 🙂 Om en ny sajt inte är prio nu säg bara till.</pre>
       </div>
 
     </div>
+  </section>
+
+  <!-- E-POST EFTER REGISTRERING + NYHETSBREV -->
+  <section class="sec" id="epost">
+    <div class="sec-h">E-post efter registrering &amp; nyhetsbrev <span class="hint">skicka manuellt samma dag tills automationen (MailerLite) är live · fulla utkast i content/email/</span></div>
+    <div class="scripts">
+
+      <div class="script">
+        <div class="script-h"><span class="nm">Välkomst — Gratis analys</span><span class="tag">0 min</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: Er analys är igång — rapporten kommer inom 24h
+
+Hej [Förnamn],
+
+tack för förfrågan! Jag har tagit emot [Klinik]s webbadress och börjar granskningen idag.
+
+Det här händer nu:
+1. Jag går igenom er sajt mot alla 10 punkter (mobil, hastighet, lokal SEO, bokningsflöde m.m.)
+2. Inom 24 timmar får ni en personlig rapport hit till er e-post
+3. Konkret lista: vad som fungerar, och vad som kostar er patienter — utan säljpitch
+
+Medan ni väntar: vår korta guide med de 3 viktigaste sakerna för att synas högre på Google →
+https://www.bahkobyra.se/kliniker/gratis-guide.html
+
+Hörs inom 24 timmar!
+
+/Mathias, Bahko Byrå</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">Välkomst — Gratis guide</span><span class="tag">0 min</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: Din guide: 3 sätt att ranka högre på Google
+
+Hej [Förnamn],
+
+kul att du vill synas högre på Google! Guiden + videon är upplåst här:
+https://www.bahkobyra.se/kliniker/gratis-guide.html
+
+Kortversionen — börja redan idag:
+1. Fyll Google Företagsprofilen till 100 % (rätt kategori, alla tjänster, 10+ riktiga foton)
+2. Sätt recensioner i system — be varje nöjd kund samma dag, mål 1–2 nya/vecka
+3. Samma namn/adress/telefon överallt — sajt, Google, Hitta, Eniro, Facebook
+
+PS: Vill du veta exakt var just din klinik ligger idag? Gratis 10-punktsanalys, svar inom 24h →
+https://www.bahkobyra.se/kliniker/gratis-granskning.html
+
+/Mathias, Bahko Byrå</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">Uppföljning dag 2 (värde)</span><span class="tag">Sekvens</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: Det vanligaste misstaget vi ser på kliniksajter
+
+Hej [Förnamn],
+
+snabb fråga: hur många klick tar det att boka en tid på er sajt — från startsidan, i mobilen?
+
+Det är det första vi kollar i varje granskning, för det är där flest bokningar försvinner.
+8 av 10 besökare sitter i mobilen. Syns inte bokningsknappen direkt går de till nästa klinik i listan.
+
+Testa ikväll: öppna er sajt i mobilen och ta tid på en bokning. Över 30 sekunder = ni tappar patienter.
+
+Vill du att jag tittar? Jag spelar in en kort video med exakt vad jag ser — gratis. Svara bara på mejlet.
+
+/Mathias, Bahko Byrå</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">Uppföljning dag 5 (knuff)</span><span class="tag">Sekvens</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: 2 minuter om [Klinik]s sajt?
+
+Hej [Förnamn],
+
+jag har en lucka i veckan och spelar gärna in en kort video (ca 2 min) om er sajt — vad som fungerar,
+och de 2–3 sakerna jag hade fixat först för fler bokningar.
+
+Kostar inget, kräver inget. Du får videon, gör vad du vill med den.
+
+Svara "ja" så har du den inom ett par dagar. Eller ta det live: https://cal.eu/bahkobyra/15min
+
+/Mathias, Bahko Byrå</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">Uppföljning dag 10 (close-loop)</span><span class="tag">Sekvens</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: Sista mejlet från mig 🙂
+
+Hej [Förnamn],
+
+jag vill inte fylla din inkorg — det här är sista mejlet i den här rundan.
+
+Om fler bokningar via sajten inte är prio just nu: helt lugnt, då hörs vi en annan gång.
+
+Om det ÄR prio: boka 15 minuter så visar jag exakt vad jag skulle göra för just er klinik —
+inklusive ett utkast på er nya startsida, innan ni betalar någonting.
+
+https://cal.eu/bahkobyra/15min
+
+Allt gott!
+
+/Mathias, Bahko Byrå</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">Nyhetsbrev — månadens mall</span><span class="tag">1/mån</span><button class="copy">Kopiera</button></div>
+        <pre>Ämne: [Månadens tips i en mening]
+
+Hej [Förnamn],
+
+[1 konkret insikt — varför detta kostar/ger bokningar. 2–3 meningar, rakt på.]
+
+Månadens fix (10 min):
+- [steg 1]
+- [steg 2]
+- [steg 3]
+
+[En mening om vad som händer när det är gjort.]
+
+Vill du ha hela bilden? Gratis 10-punktsanalys, svar inom 24h →
+https://www.bahkobyra.se/kliniker/gratis-granskning.html
+
+/Mathias, Bahko Byrå
+
+— 3 färdigskrivna utskick (juni/juli/aug) finns i content/email/nyhetsbrev-2026-q3.md</pre>
+      </div>
+
+    </div>
+    <p class="note">Flöde: registrering → välkomstmejl samma dag → dag 2 → dag 5 → dag 10. <strong>Stoppa sekvensen direkt vid svar eller bokning.</strong> Nya prenumeranter (footer-formuläret) får ämnesraden "Ny prenumerant – nyhetsbrev" i Formspree-inkorgen.</p>
   </section>
 
   <!-- INSTAGRAM-MOTOR -->

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -213,6 +213,7 @@
       </h2>
       <p class="lede" data-reveal style="margin-top:1.4rem">Vi bygger ett fullständigt demo innan du bestämmer dig. Se bokningssystem, animationer och design i verklighet — inte i mockups.</p>
       <a href="https://www.bahkobyra.se/cloud/" target="_blank" rel="noopener" class="demo-link magnetic" data-magnetic=".25" data-reveal>Öppna Demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
+      <p class="demo-proof" data-reveal="0.1">Senaste skarpa leverans: <a href="https://maykaskitchen.se" target="_blank" rel="noopener">maykaskitchen.se</a></p>
     </div>
   </div>
 </section>

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -148,7 +148,7 @@
 <section class="dark" style="padding-top:0;padding-bottom:0">
   <div class="stats">
     <div class="stat" data-reveal><div class="stat-v"><span data-count="30" data-suffix=" dgr">0</span></div><div class="stat-l">Resultatgaranti</div></div>
-    <div class="stat" data-reveal="0.05"><div class="stat-v"><span data-count="87" data-suffix="+">0</span></div><div class="stat-l">Klinikleads Klara</div></div>
+    <div class="stat" data-reveal="0.05"><div class="stat-v"><span data-count="24" data-suffix="h">0</span></div><div class="stat-l">Svar På Gratis Analys</div></div>
     <div class="stat" data-reveal="0.1"><div class="stat-v"><span data-count="3" data-suffix="x">0</span></div><div class="stat-l">Mer Organisk Trafik</div></div>
     <div class="stat" data-reveal="0.15"><div class="stat-v"><span data-count="100" data-suffix="%">0</span></div><div class="stat-l">Fokus På Ditt Resultat</div></div>
   </div>
@@ -282,6 +282,7 @@
       </div>
       <div class="field"><label for="cf-epost">E-post</label><input type="email" id="cf-epost" name="email" placeholder="anna@dinverksamhet.se" required autocomplete="email"></div>
       <div class="field"><label for="cf-msg">Hur kan vi hjälpa dig?</label><textarea id="cf-msg" name="meddelande" placeholder="Berätta kort om din verksamhet och vad du vill uppnå..."></textarea></div>
+      <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px">
       <input type="hidden" name="_subject" value="Ny kontaktförfrågan – startsidan (bahkobyra.se)">
       <button class="btn btn-gold magnetic" data-magnetic=".2" type="submit"><span>Skicka Förfrågan</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></button>
     </form>
@@ -302,11 +303,26 @@
       <a href="#kontakt" class="btn btn-gold magnetic" data-magnetic=".25"><span>Starta Ditt Projekt</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
     </div>
   </div>
+  <div class="foot-nl">
+    <div class="foot-nl-copy">
+      <h4>Ett konkret tillväxttips i månaden</h4>
+      <p>Hur kliniker syns högre på Google och får fler bokningar. Inget brus — avregistrera när du vill.</p>
+    </div>
+    <form class="foot-nl-form" id="nlform" action="https://formspree.io/f/mgonrnep" method="POST">
+      <input type="email" name="email" placeholder="du@dinklinik.se" required autocomplete="email" aria-label="Din e-post">
+      <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px">
+      <input type="hidden" name="_subject" value="Ny prenumerant – nyhetsbrev (footer bahkobyra.se)">
+      <button class="btn btn-gold" type="submit"><span>Prenumerera</span></button>
+    </form>
+    <p class="foot-nl-ok" id="nl-ok">✓ Tack! Du är med — första tipset landar i din inkorg snart.</p>
+  </div>
   <div class="foot-bottom">
     <span>© 2026 Bahko Byrå</span>
     <div class="foot-links">
       <a href="#tjanster">Tjänster</a>
       <a href="/kliniker/gratis-granskning.html">Gratis Analys</a>
+      <a href="/kliniker/gratis-guide.html">Gratis Guide</a>
+      <a href="https://www.bahkobyra.se/cloud/" target="_blank" rel="noopener">Live Demo</a>
     </div>
     <span>bahkobyra.se</span>
   </div>

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -109,10 +109,8 @@
 <!-- HERO -->
 <section class="hero" id="top">
   <div class="hero-img">
-    <video id="hero-video"
-      src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260525_134138_7ea92be9-f174-4971-9c0c-3dd3729da6e7.mp4"
-      poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260525_225124_b47c5542-a0f5-406b-b12d-ed95eb0bde39.png"
-      muted playsinline preload="auto" aria-hidden="true"></video>
+    <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260525_225124_b47c5542-a0f5-406b-b12d-ed95eb0bde39.png"
+      alt="" fetchpriority="high" decoding="async" aria-hidden="true">
   </div>
   <div class="hero-grain"></div>
 

--- a/bahkobyra/js/main.js
+++ b/bahkobyra/js/main.js
@@ -204,33 +204,6 @@
     });
   }
 
-  /* ── SCROLL-DRIVEN HERO VIDEO ──────────────────────────── */
-  function initHeroVideo() {
-    const video = doc.getElementById('hero-video');
-    if (!video || !hasST || reduce) return;
-
-    const setup = () => {
-      const dur = video.duration;
-      if (!dur || isNaN(dur)) return;
-
-      ScrollTrigger.create({
-        trigger: '.hero',
-        start: 'top top',
-        end: '+=110%',
-        pin: true,
-        anticipatePin: 1,
-        scrub: 0.6,
-        invalidateOnRefresh: true,
-        onUpdate: (self) => {
-          if (video.readyState >= 2) video.currentTime = self.progress * dur;
-        }
-      });
-    };
-
-    if (video.readyState >= 1) setup();
-    else video.addEventListener('loadedmetadata', setup, { once: true });
-  }
-
   /* ── COUNTERS ──────────────────────────────────────────── */
   function initCounters() {
     $$('[data-count]').forEach((el) => {
@@ -509,7 +482,6 @@
   /* ── BOOT ──────────────────────────────────────────────── */
   function boot() {
     initSmooth();
-    initHeroVideo();
     initHeader();
     initProgress();
     initReveals();

--- a/bahkobyra/js/main.js
+++ b/bahkobyra/js/main.js
@@ -393,13 +393,40 @@
   /* ── AUDIT POPUP ───────────────────────────────────────── */
   function initPopup() {
     const pop = $('#pop'); if (!pop) return;
+    // Visas en gång per besökare, max var 7:e dag — aldrig på nytt i samma session.
+    const KEY = 'bb_pop_seen';
+    try { if (Date.now() - (+localStorage.getItem(KEY) || 0) < 7 * 864e5) return; } catch (e) { /* visa ändå */ }
     const x = $('#pop-x');
-    const show = () => pop.classList.add('show');
+    const seen = () => { try { localStorage.setItem(KEY, Date.now()); } catch (e) {} };
+    const show = () => { pop.classList.add('show'); seen(); };
     const hide = () => pop.classList.remove('show');
     if (x) x.addEventListener('click', hide);
     pop.addEventListener('click', (e) => { if (e.target === pop) hide(); });
     addEventListener('keydown', (e) => { if (e.key === 'Escape') hide(); });
-    setTimeout(() => { show(); setInterval(show, 90000); }, 18000);
+    setTimeout(show, 22000);
+  }
+
+  /* ── NEWSLETTER (footer) ───────────────────────────────── */
+  function initNewsletter() {
+    const form = $('#nlform'); if (!form) return;
+    const box = form.closest('.foot-nl');
+    const btn = $('button[type="submit"]', form);
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (btn) btn.disabled = true;
+      try {
+        const res = await fetch(form.action, {
+          method: 'POST',
+          body: new FormData(form),
+          headers: { 'Accept': 'application/json' }
+        });
+        if (!res.ok) throw new Error('bad response');
+        if (box) box.classList.add('sent');
+      } catch {
+        if (btn) btn.disabled = false;
+        alert('Något gick fel. Försök igen eller mejla oss direkt på mathias@bahkobyra.se');
+      }
+    });
   }
 
   /* ── EXTRAS: marquee, CTA glow, stat labels, proc hint ─── */
@@ -498,6 +525,7 @@
     initCursor();
     initNav();
     initForm();
+    initNewsletter();
     initPopup();
 
     // hero entrance — each element gets its own distinct animation type

--- a/bahkobyra/kliniker/gratis-granskning.html
+++ b/bahkobyra/kliniker/gratis-granskning.html
@@ -7,6 +7,15 @@
 <meta name="description" content="Få en gratis 10-punktsanalys av er kliniksajt. Vi granskar SEO, mobilanpassning, bokningsflöde och mer — helt gratis, utan krav.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://www.bahkobyra.se/kliniker/gratis-granskning.html">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.bahkobyra.se/kliniker/gratis-granskning.html">
+<meta property="og:title" content="Gratis Webbplatsanalys för Kliniker | Bahko Byrå">
+<meta property="og:description" content="10-punktsanalys av er kliniksajt — SEO, mobilanpassning, bokningsflöde. Helt gratis, svar inom 24h.">
+<meta property="og:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
+<meta property="og:locale" content="sv_SE">
+
 <link rel="icon" type="image/png" href="../favicon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -109,6 +118,9 @@ form{display:flex;flex-direction:column;gap:1rem}
 .field input{background:rgba(245,242,235,.06);border:1px solid rgba(201,169,110,.2);border-radius:var(--r);padding:.9rem 1.1rem;color:var(--paper);font-family:var(--sans);font-size:.95rem;font-weight:300;outline:none;transition:border-color .3s,background .3s;-webkit-appearance:none;appearance:none}
 .field input:focus{border-color:rgba(201,169,110,.55);background:rgba(245,242,235,.1)}
 .field input::placeholder{color:rgba(245,242,235,.22)}
+.field select{background:rgba(245,242,235,.06);border:1px solid rgba(201,169,110,.2);border-radius:var(--r);padding:.9rem 1.1rem;color:var(--paper);font-family:var(--sans);font-size:.95rem;font-weight:300;outline:none;transition:border-color .3s,background .3s;-webkit-appearance:none;appearance:none;cursor:pointer;width:100%}
+.field select:focus{border-color:rgba(201,169,110,.55);background:rgba(245,242,235,.1)}
+.field select option{background:var(--navy);color:var(--paper)}
 .field-row{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
 
 .submit-btn{margin-top:.6rem;padding:1.05rem 2.2rem;background:var(--gold);color:var(--navy-2);font-family:var(--sans);font-size:.82rem;font-weight:600;letter-spacing:.14em;text-transform:uppercase;border-radius:var(--r);cursor:pointer;transition:background .3s,transform .15s,box-shadow .3s;position:relative;overflow:hidden}
@@ -125,6 +137,8 @@ form{display:flex;flex-direction:column;gap:1rem}
 .success-ic{width:56px;height:56px;border-radius:50%;border:1px solid var(--line-2);display:grid;place-items:center;margin:0 auto 1.4rem;color:var(--gold);font-size:1.4rem}
 .success h3{font-family:var(--display);font-size:1.8rem;font-weight:500;margin-bottom:.5rem}
 .success p{font-size:.88rem;color:var(--paper-70);line-height:1.7;font-weight:300}
+.success-link{display:inline-block;margin-top:1.6rem;font-size:.8rem;color:var(--gold-lt);border:1px solid rgba(201,169,110,.35);border-radius:var(--r);padding:.75rem 1.3rem;transition:background .3s,color .3s}
+.success-link:hover{background:var(--gold);color:var(--navy)}
 
 /* ── FOOTER ── */
 footer{padding:2.5rem var(--gut);text-align:center;border-top:1px solid var(--line);background:var(--cream-2)}
@@ -159,7 +173,7 @@ footer a:hover{color:var(--gold-dk)}
 <section class="hero">
   <div class="hero-badge">Gratis — värde 799 kr · Svar inom 24h</div>
   <h1 class="hero-title">Hur ser din kliniksajt<br>ut i <em>köparens ögon?</em></h1>
-  <p class="hero-sub">Vi gör en 10-punktsanalys av er webbplats och skickar resultatet direkt till er — helt gratis. Inga strings attached.</p>
+  <p class="hero-sub">Vi gör en 10-punktsanalys av er webbplats och skickar resultatet direkt till er — helt gratis, utan krav och utan säljpitch.</p>
   <div class="hero-stats">
     <div class="hero-stat">
       <div class="hero-stat-n">10</div>
@@ -298,7 +312,7 @@ footer a:hover{color:var(--gold-dk)}
       <div class="field-row">
         <div class="field">
           <label for="namn">Ditt namn</label>
-          <input type="text" id="namn" name="namn" placeholder="Mathias Eriksson" required autocomplete="name">
+          <input type="text" id="namn" name="namn" placeholder="Anna Svensson" required autocomplete="name">
         </div>
         <div class="field">
           <label for="klinik">Klinikens namn</label>
@@ -313,6 +327,17 @@ footer a:hover{color:var(--gold-dk)}
         <label for="email">Er e-post</label>
         <input type="email" id="email" name="email" placeholder="hej@erkliniksajt.se" required autocomplete="email">
       </div>
+      <div class="field">
+        <label for="utmaning">Er största utmaning just nu <span style="text-transform:none;letter-spacing:.04em;opacity:.6">(valfritt)</span></label>
+        <select id="utmaning" name="utmaning">
+          <option value="">Välj…</option>
+          <option>Fler bokningar</option>
+          <option>Synas högre på Google</option>
+          <option>Hemsidan känns gammal</option>
+          <option>Vet inte — det är därför jag vill ha analysen</option>
+        </select>
+      </div>
+      <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px">
       <input type="hidden" name="_subject" value="Ny audit-förfrågan från webbplatsanalys">
       <button class="submit-btn" type="submit" id="submit-btn">Skicka — helt gratis</button>
       <p class="form-note">Vi delar aldrig er information. Ni kan avregistrera er när som helst.</p>
@@ -320,8 +345,10 @@ footer a:hover{color:var(--gold-dk)}
 
     <div class="success" id="success-msg">
       <div class="success-ic">✓</div>
-      <h3>Tack — vi återkommer inom 24h!</h3>
+      <h3>Tack — rapporten landar inom 24h!</h3>
       <p>Mathias på Bahko Byrå granskar er sajt och skickar rapporten till er e-post.<br>Kolla gärna skräpposten om ni inte hör av oss.</p>
+      <a class="success-link" href="/kliniker/gratis-guide.html">Medan ni väntar: 3 sätt att ranka högre på Google — gratis guide + video
+        <svg viewBox="0 0 24 24" style="width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none;vertical-align:-2px;margin-left:.3rem"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
     </div>
   </div>
 </div>

--- a/bahkobyra/kliniker/gratis-guide.html
+++ b/bahkobyra/kliniker/gratis-guide.html
@@ -152,6 +152,7 @@
           <label for="g-epost">E-post</label>
           <input type="email" id="g-epost" name="email" placeholder="du@dinklinik.se" required autocomplete="email">
         </div>
+        <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px">
         <input type="hidden" name="_subject" value="Ny guide-nedladdning – lead magnet (gratis-guide)">
         <button class="btn" type="submit" id="g-btn"><span>Lås upp guiden + videon</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></button>
         <p class="fine">Ingen bindning. Vi spammar inte. Avregistrera när du vill.</p>
@@ -258,6 +259,16 @@
   const optin = document.getElementById('optin');
   const guide = document.getElementById('guide-content');
   const btn = document.getElementById('g-btn');
+  const UNLOCK_KEY = 'bb_guide_unlocked';
+
+  function unlock(scroll) {
+    optin.style.display = 'none';
+    guide.classList.add('show');
+    if (scroll) guide.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  // Redan registrerad? Guiden förblir upplåst vid återbesök.
+  try { if (localStorage.getItem(UNLOCK_KEY)) unlock(false); } catch {}
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -270,9 +281,8 @@
         headers: { 'Accept': 'application/json' }
       });
       if (!res.ok) throw new Error('bad response');
-      optin.style.display = 'none';
-      guide.classList.add('show');
-      guide.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      try { localStorage.setItem(UNLOCK_KEY, '1'); } catch {}
+      unlock(true);
     } catch {
       btn.disabled = false;
       btn.querySelector('span').textContent = 'Lås upp guiden + videon';

--- a/bahkobyra/sitemap.xml
+++ b/bahkobyra/sitemap.xml
@@ -2,25 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.bahkobyra.se/</loc>
-    <lastmod>2026-06-06</lastmod>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://www.bahkobyra.se/kliniker/gratis-granskning.html</loc>
-    <lastmod>2026-06-06</lastmod>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.bahkobyra.se/kliniker/gratis-guide.html</loc>
-    <lastmod>2026-06-06</lastmod>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.bahkobyra.se/cloud/</loc>
-    <lastmod>2026-06-06</lastmod>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/content/email/nyhetsbrev-2026-q3.md
+++ b/content/email/nyhetsbrev-2026-q3.md
@@ -1,0 +1,87 @@
+# Nyhetsbrev — tre färdiga utskick (Q3 2026)
+
+**Format:** 1 konkret tips + 1 mini-checklista + 1 CTA. Kort nog att läsas på 90 sekunder.
+**Frekvens:** 1/månad. **Avsändare:** Mathias, Bahko Byrå (mathias@bahkobyra.se).
+**Prenumeranter kommer från:** footer-formuläret på bahkobyra.se (ämnesrad "Ny prenumerant – nyhetsbrev").
+**Regel:** värde först, pitch sist — alltid. Aldrig mer än en CTA.
+
+---
+
+## Utskick 1 (juni) — Google Företagsprofilen
+
+**Ämne:** Därför ligger kliniken under dig högre på Google
+
+Hej [Förnamn],
+
+en obekväm sanning: Google rankar inte den *bästa* kliniken högst — den rankar den som gjort läxan.
+Och läxan nummer ett är Google Företagsprofilen (rutan med kartan när någon söker "[behandling] [stad]").
+
+**Månadens 10-minutersfix:**
+- Öppna din profil via google.com/business
+- Kolla huvudkategorin — är den *exakt* rätt? ("Hudvårdsklinik", inte "Klinik")
+- Räkna dina foton. Färre än 10? Ladda upp riktiga bilder: lokalen, teamet, resultat
+- Fyll i varje tjänst ni erbjuder, med en mening beskrivning per tjänst
+
+En halvtom profil som blir 100 % ifylld rör sig ofta uppåt inom ett par veckor. Gratis synlighet.
+
+Vill du veta exakt var din klinik ligger idag — och vad som håller er nere?
+**Gratis 10-punktsanalys, svar inom 24h →** https://www.bahkobyra.se/kliniker/gratis-granskning.html
+
+/Mathias, Bahko Byrå
+
+---
+
+## Utskick 2 (juli) — Recensionsmotorn
+
+**Ämne:** 1–2 recensioner i veckan slår 200 på en gång
+
+Hej [Förnamn],
+
+när en patient jämför två kliniker väljer hon nästan alltid den med flest och *färskast* recensioner.
+Google gör samma bedömning. Ändå ber de flesta kliniker aldrig om recensioner — eller bara i en kampanj
+en gång om året.
+
+**Månadens system (sätt upp en gång, kör för alltid):**
+- Skapa din recensionslänk i Företagsprofilen och korta ner den (t.ex. via en QR-kod i receptionen)
+- Be **varje** nöjd patient — samma dag, via SMS. Ett klick för dem
+- Svara på alla recensioner, även de sura. Lugnt och professionellt — alla läser dina svar
+- Mål: 1–2 nya i veckan. Jämnt flöde slår engångspuckel, varje gång
+
+Börja idag: skicka länken till dina tre senaste nöjda patienter.
+
+**Vill du ha hela bilden av er synlighet? Gratis analys →** https://www.bahkobyra.se/kliniker/gratis-granskning.html
+
+/Mathias, Bahko Byrå
+
+---
+
+## Utskick 3 (augusti) — Sajten som bokningsmotor
+
+**Ämne:** Din sajt får besökare. Får den bokningar?
+
+Hej [Förnamn],
+
+trafik är bara halva jobbet. Andra halvan: vad händer när någon faktiskt landar på er sajt — i mobilen,
+kl 21 en tisdag? Det är där de flesta kliniker läcker patienter utan att märka det.
+
+**Månadens självtest (ta 5 minuter ikväll):**
+- Öppna er sajt i mobilen. Syns "Boka tid" utan att scrolla?
+- Ta tid: hur många sekunder tar det att genomföra en bokning? Över 30 = ni tappar folk
+- Laddar sidan på under 3 sekunder? (Testa på pagespeed.web.dev)
+- Finns riktiga bilder och recensioner synliga — eller bara stockfoton?
+
+Varje besökare som studsar är en patient som bokar hos konkurrenten i stället.
+
+**Vill du se hur en kliniksajt byggd för bokningar känns? Kika på vårt demo →** https://www.bahkobyra.se/cloud/
+Eller boka 15 min så går vi igenom just er sajt: https://cal.eu/bahkobyra/15min
+
+/Mathias, Bahko Byrå
+
+---
+
+## Kommande ämnen (idébank)
+
+- September: Före/efter-bilder + SEO — hur resultatsidor rankar
+- Oktober: "Boka direkt"-flöden vs kontaktformulär — vad datan säger
+- November: Google Ads för kliniker — när det är värt det (och när det inte är det)
+- December: Årsgenomgång — checklistan inför nya året

--- a/content/email/valkomstmejl-och-sekvens.md
+++ b/content/email/valkomstmejl-och-sekvens.md
@@ -1,0 +1,126 @@
+# Välkomstmejl & uppföljningssekvens — efter registrering
+
+**Trigger:** någon fyller i ett formulär på bahkobyra.se (gratis analys, gratis guide eller nyhetsbrev).
+**Tills automationen finns (MailerLite/Brevo):** skicka manuellt från mathias@bahkobyra.se samma dag.
+**När automationen finns:** lägg in mejlen nedan som sekvens (0 min → dag 2 → dag 5 → dag 10).
+**Regel:** "Växa på Google"-copy är OK här — det är bahkobyra.se-trafik (inbound), inte outreach.
+**Snabbkopiering:** alla mejl finns även som kopieringskort i dashboarden (sektion "E-post efter registrering").
+
+---
+
+## 1. Välkomstmejl — GRATIS ANALYS (skicka direkt, 0 min)
+
+**Ämne:** Er analys är igång — rapporten kommer inom 24h
+
+Hej [Förnamn],
+
+tack för förfrågan! Jag har tagit emot [Klinik]s webbadress och börjar granskningen idag.
+
+Det här händer nu:
+1. Jag går igenom er sajt mot alla 10 punkter (mobil, hastighet, lokal SEO, bokningsflöde m.m.)
+2. Inom 24 timmar får ni en personlig rapport hit till er e-post
+3. Konkret lista: vad som fungerar, och vad som kostar er patienter — utan säljpitch
+
+Medan ni väntar: här är vår korta guide med de 3 viktigaste sakerna för att synas
+högre på Google → https://www.bahkobyra.se/kliniker/gratis-guide.html
+
+Hörs inom 24 timmar!
+
+/Mathias, Bahko Byrå
+mathias@bahkobyra.se
+
+---
+
+## 2. Välkomstmejl — GRATIS GUIDE (skicka direkt, 0 min)
+
+**Ämne:** Din guide: 3 sätt att ranka högre på Google
+
+Hej [Förnamn],
+
+kul att du vill synas högre på Google! Guiden + videon är upplåst här:
+https://www.bahkobyra.se/kliniker/gratis-guide.html
+
+Kortversionen — börja med detta redan idag:
+1. **Fyll Google Företagsprofilen till 100 %** — rätt huvudkategori, alla tjänster, minst 10 riktiga foton
+2. **Sätt recensioner i system** — be varje nöjd kund samma dag, mål 1–2 nya/vecka
+3. **Samma namn/adress/telefon överallt** — sajt, Google, Hitta, Eniro, Facebook
+
+Tips 1 ger oftast synlig rörelse inom ett par veckor.
+
+PS: Vill du veta exakt var just din klinik ligger idag? Vi gör en gratis 10-punktsanalys
+av er sajt — svar inom 24h → https://www.bahkobyra.se/kliniker/gratis-granskning.html
+
+/Mathias, Bahko Byrå
+
+---
+
+## 3. Uppföljning — DAG 2 (värde, ingen pitch)
+
+**Ämne:** Det vanligaste misstaget vi ser på kliniksajter
+
+Hej [Förnamn],
+
+snabb fråga: hur många klick tar det att boka en tid på er sajt — från startsidan, i mobilen?
+
+Det är det första vi kollar i varje granskning, för det är där flest bokningar försvinner.
+8 av 10 besökare sitter i mobilen, ofta på kvällen. Om bokningsknappen inte syns direkt,
+eller formuläret kräver fem steg, går de vidare till nästa klinik i listan.
+
+Testa själv ikväll: öppna er sajt i mobilen och ta tid på hur lång tid det tar att boka.
+Mer än 30 sekunder = ni tappar patienter varje vecka.
+
+Vill du att jag tittar? Jag spelar gärna in en kort video med exakt vad jag ser på er sajt — gratis.
+Svara bara på det här mejlet.
+
+/Mathias, Bahko Byrå
+
+---
+
+## 4. Uppföljning — DAG 5 (personlig knuff)
+
+**Ämne:** 2 minuter om [Klinik]s sajt?
+
+Hej [Förnamn],
+
+jag har en ledig lucka i veckan och spelar gärna in en kort video (ca 2 min) där jag går
+igenom er sajt — vad som fungerar, och de 2–3 sakerna jag hade fixat först för fler bokningar.
+
+Kostar inget, kräver inget. Du får videon, gör vad du vill med den.
+
+Vill du ha den? Svara "ja" så har du den inom ett par dagar.
+Eller boka 15 minuter direkt så går vi igenom det live: https://cal.eu/bahkobyra/15min
+
+/Mathias, Bahko Byrå
+
+---
+
+## 5. Uppföljning — DAG 10 (close-loop, sista mejlet)
+
+**Ämne:** Sista mejlet från mig 🙂
+
+Hej [Förnamn],
+
+jag vill inte fylla din inkorg — det här är sista mejlet i den här rundan.
+
+Om fler bokningar via sajten inte är prio just nu: helt lugnt, då hörs vi en annan gång.
+Du har kvar guiden och kan alltid boka en gratis analys senare.
+
+Om det ÄR prio: boka 15 minuter så visar jag exakt vad jag skulle göra för just er klinik —
+inklusive ett utkast på hur er nya startsida kan se ut, innan ni betalar någonting.
+
+https://cal.eu/bahkobyra/15min
+
+Allt gott!
+
+/Mathias, Bahko Byrå
+
+---
+
+## Setup-checklista (görs en gång)
+
+- [ ] Skapa konto på MailerLite eller Brevo (gratis upp till ~1 000 kontakter)
+- [ ] Formspree → Settings → Webhooks/Integrations → koppla nya leads till listan
+- [ ] Tre grupper/taggar: `analys`, `guide`, `nyhetsbrev` (styr vilket välkomstmejl som går ut)
+- [ ] Lägg in sekvensen: 0 min → dag 2 → dag 5 → dag 10 (stoppa sekvensen vid svar/bokning)
+- [ ] Verifiera avsändardomän (SPF + DKIM för bahkobyra.se) så mejlen inte hamnar i skräppost
+- [ ] Testa hela flödet med din egen e-post innan den går live

--- a/server.js
+++ b/server.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * server.js — Lokal dev-server för Bahko Byrå
- * Kör: node server.js
- * Öppnar automatiskt i Edge på http://localhost:3000
+ * Kör: node server.js → http://localhost:3001
+ * Speglar Vercel: webbroot = bahkobyra/ (precis som i produktion).
+ * Öppnar automatiskt i Edge.
  */
 
 import { createServer } from 'http';
@@ -63,7 +64,10 @@ const server = createServer((req, res) => {
 
   if (urlPath === '/') urlPath = '/index.html';
 
-  let filePath = join(__dirname, urlPath);
+  // Webbroot = bahkobyra/ (matchar Vercels outputDirectory). Repo-rotens
+  // .tmp/ förblir nåbar för lokala rapporter.
+  const base = urlPath.startsWith('/.tmp/') ? __dirname : join(__dirname, 'bahkobyra');
+  let filePath = join(base, urlPath);
 
   // Serve index.html for directory requests
   if (existsSync(filePath) && statSync(filePath).isDirectory()) {
@@ -96,12 +100,12 @@ server.listen(PORT, () => {
   console.log('══════════════════════════════════════');
   console.log(`  ${url}`);
   console.log('──────────────────────────────────────');
-  console.log(`  Hub:       ${url}/`);
-  console.log(`  Byrå:      ${url}/bahkobyra/`);
-  console.log(`  Pitch:     ${url}/bahkobyra/pitchdeck.html`);
-  console.log(`  Demo:      ${url}/kliniker/elara-klinik-demo-v2.html`);
-  console.log(`  CRM:       ${url}/kliniker/crm.html`);
-  console.log(`  Rapport:   ${url}/.tmp/competitor_report_2026-03-16.html`);
+  console.log(`  Byrå:      ${url}/`);
+  console.log(`  Analys:    ${url}/kliniker/gratis-granskning.html`);
+  console.log(`  Guide:     ${url}/kliniker/gratis-guide.html`);
+  console.log(`  Demo:      ${url}/cloud/`);
+  console.log(`  Dashboard: ${url}/dashboard/`);
+  console.log(`  Pitch:     ${url}/pitchdeck.html`);
   console.log('──────────────────────────────────────');
   console.log('  Ctrl+C för att stänga\n');
 

--- a/tools/enrich_crm_contacts.js
+++ b/tools/enrich_crm_contacts.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * enrich_crm_contacts.js — Fyller i mejl/telefon för dashboardens CRM-seed.
+ *
+ * Besöker varje kliniks sajt (startsida + vanliga kontaktsidor), plockar
+ * e-post (mailto: + text) och telefon (tel: + svenska format) och skriver
+ * resultatet till .tmp/crm_contacts.json.
+ *
+ * Kör:   node tools/enrich_crm_contacts.js            # hämta + visa resultat
+ *        node tools/enrich_crm_contacts.js --apply    # skriv även in i dashboardens SEED
+ *
+ * OBS: kräver fri utgående nätåtkomst (kör lokalt, inte i sandlådad miljö).
+ * Efter --apply: dashboardens CRM ligger i localStorage — exportera ev. Backup
+ * först, ladda om dashboarden med rensad bb_crm_v1 för att läsa in nya seeden.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const DASH = join(ROOT, 'bahkobyra', 'dashboard', 'index.html');
+const OUT = join(ROOT, '.tmp', 'crm_contacts.json');
+const APPLY = process.argv.includes('--apply');
+
+const CONTACT_PATHS = ['', '/kontakt', '/kontakta-oss', '/contact', '/kontakt-oss', '/om-oss'];
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+const PHONE_RE = /(?:tel:|callto:)?(\+46[\s\-()]?\d[\d\s\-()]{6,12}|0\d{1,3}[\s\-]?\d{2,3}[\s\-]?\d{2,3}[\s\-]?\d{2,3})/g;
+const SKIP_EMAIL = /\.(png|jpg|jpeg|webp|svg|gif)$|sentry|wixpress|example\.|@2x/i;
+
+function readSeed() {
+  const html = readFileSync(DASH, 'utf8');
+  const rows = [...html.matchAll(/\{id:'(s\d+)',name:'((?:[^'\\]|\\.)*)',web:'([^']*)'[^}]*?phone:'([^']*)',email:'([^']*)'/g)];
+  return rows.map(m => ({ id: m[1], name: m[2].replace(/\\'/g, "'"), web: m[3], phone: m[4], email: m[5] }));
+}
+
+async function fetchText(url) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), 12000);
+  try {
+    const res = await fetch(url, {
+      signal: ctl.signal,
+      redirect: 'follow',
+      headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/126 Safari/537.36', 'Accept-Language': 'sv-SE,sv;q=0.9' }
+    });
+    if (!res.ok) return '';
+    return await res.text();
+  } catch { return ''; } finally { clearTimeout(t); }
+}
+
+function pickEmail(emails, domain) {
+  const clean = [...new Set(emails.map(e => e.toLowerCase()))].filter(e => !SKIP_EMAIL.test(e));
+  if (!clean.length) return '';
+  // Prioritera egna domänen, sedan info@/kontakt@, sedan första bästa
+  const own = clean.filter(e => domain && e.endsWith('@' + domain.replace(/^www\./, '')));
+  const pool = own.length ? own : clean;
+  return pool.find(e => /^(info|kontakt|hej|booking|bokning)@/.test(e)) || pool[0];
+}
+
+function pickPhone(phones) {
+  const clean = [...new Set(phones.map(p => p.replace(/^(tel:|callto:)/, '').trim()))]
+    .filter(p => p.replace(/\D/g, '').length >= 8);
+  return clean[0] || '';
+}
+
+async function enrich(lead) {
+  let domain = '';
+  try { domain = new URL(lead.web).hostname; } catch { return { ...lead, status: 'ogiltig URL' }; }
+  const emails = [], phones = [];
+  for (const path of CONTACT_PATHS) {
+    const html = await fetchText(lead.web.replace(/\/$/, '') + path);
+    if (!html) continue;
+    emails.push(...(html.match(EMAIL_RE) || []), ...[...html.matchAll(/mailto:([^"'?]+)/g)].map(m => m[1]));
+    phones.push(...(html.match(PHONE_RE) || []), ...[...html.matchAll(/tel:([+\d\s\-()]+)/g)].map(m => m[1]));
+    if (emails.length && phones.length) break;
+  }
+  const email = lead.email || pickEmail(emails, domain);
+  const phone = lead.phone || pickPhone(phones);
+  return { ...lead, email, phone, status: email || phone ? 'hittad' : 'kolla manuellt' };
+}
+
+const leads = readSeed();
+console.log(`Hittade ${leads.length} leads i dashboard-seeden. Hämtar kontaktuppgifter…\n`);
+
+const results = [];
+for (const lead of leads) {
+  const r = await enrich(lead);
+  results.push(r);
+  console.log(`  ${r.status === 'hittad' ? '✓' : '·'} ${r.name.padEnd(32)} ${r.email || '—'}  ${r.phone || ''}`);
+}
+
+mkdirSync(join(ROOT, '.tmp'), { recursive: true });
+writeFileSync(OUT, JSON.stringify(results, null, 2));
+const found = results.filter(r => r.status === 'hittad').length;
+console.log(`\n${found}/${results.length} med kontaktuppgift → ${OUT}`);
+console.log(results.filter(r => r.status !== 'hittad').length
+  ? 'Resterande: slå upp manuellt (Google "[namn] kontakt" eller Instagram-bio).' : 'Alla klara!');
+
+if (APPLY) {
+  let html = readFileSync(DASH, 'utf8');
+  let patched = 0;
+  for (const r of results) {
+    html = html.replace(new RegExp(`(\\{id:'${r.id}',[^}]*?phone:')[^']*(',email:')[^']*(')`),
+      (_, a, b, c) => { patched++; return a + r.phone + b + r.email + c; });
+  }
+  writeFileSync(DASH, html);
+  console.log(`\n--apply: ${patched} seed-rader uppdaterade i dashboarden.`);
+  console.log('OBS: har du redan öppnat dashboarden ligger gamla CRM:et i localStorage.');
+  console.log('Ta Backup först → rensa nyckeln bb_crm_v1 → ladda om för att läsa in nya seeden.');
+}


### PR DESCRIPTION
Fullständig CEO-genomgång av allt kundvänt. Detaljer i `CEO_AUDIT.md`.

## Ändrat (saker som aktivt skadade)
- Intern pipelinesiffra ("87+ Klinikleads Klara") på startsidan → ersatt med kundlöftet "24h Svar På Gratis Analys"
- Popupen återkom var 90:e sekund → visas en gång, sedan tyst i 7 dagar
- Demon (Élara): hero sa "4 900+ patienter", statistiken räknade till 4 200 → konsekvent 4 900+
- "Inga strings attached" + säljarens eget namn som formulärplaceholder på analys-sidan → fixat
- **Hero på startsidan: enkel stillbild istället för scroll-styrd video** (pin/scrub-logik borttagen)

## Förbättrat
- Guidens upplåsning sparas mellan besök (localStorage)
- Analys-sidans tacksida länkar till guiden som direktvärde + nytt kvalificeringsfält
- Honeypot-spamskydd på alla fyra formulär
- Nyhetsbrevsregistrering + fler länkar i footern, OG-taggar på analys-sidan
- Dev-servern speglar Vercels webbroot (tidigare 4 döda länkar i loggen)

## Fattades — nu byggt
- `content/email/valkomstmejl-och-sekvens.md` — 5 färdiga mejl (välkomst analys/guide, dag 2/5/10) + MailerLite-checklista
- `content/email/nyhetsbrev-2026-q3.md` — 3 färdigskrivna nyhetsbrev + idébank
- Ny dashboardsektion "E-post efter registrering &amp; nyhetsbrev" med allt som kopieringskort

## Verifierat
- `node --check` på all ändrad JS
- Alla 12 sidrutter testade lokalt → 200 OK

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_