### PR TITLE
Hero: video från /media/hero.mp4 med poster-fallback

### DIFF
--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -109,8 +109,11 @@
 <!-- HERO -->
 <section class="hero" id="top">
   <div class="hero-img">
-    <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260525_225124_b47c5542-a0f5-406b-b12d-ed95eb0bde39.png"
-      alt="" fetchpriority="high" decoding="async" aria-hidden="true">
+    <!-- Videon laddas från /media/hero.mp4 (se bahkobyra/media/README.md).
+         Saknas filen visas postern — sajten ser hel ut ändå. -->
+    <video src="/media/hero.mp4"
+      poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260525_225124_b47c5542-a0f5-406b-b12d-ed95eb0bde39.png"
+      autoplay muted loop playsinline preload="metadata" aria-hidden="true"></video>
   </div>
   <div class="hero-grain"></div>
 

--- a/bahkobyra/media/README.md
+++ b/bahkobyra/media/README.md
@@ -1,0 +1,21 @@
+# Hero-video
+
+Lägg hero-videon här med filnamnet exakt: **`hero.mp4`**
+
+Startsidans hero (`bahkobyra/index.html`) pekar på `/media/hero.mp4` och spelar den
+automatiskt (loopad, ljudlös). Saknas filen visas poster-bilden istället — sajten
+ser hel ut ändå.
+
+## Så laddar du upp (GitHub i webbläsaren)
+
+1. Ladda ner videon från Google Drive till din dator
+2. Gå till github.com/BahkoStudio/BahkoByra → mappen `bahkobyra/media/`
+3. **Add file → Upload files** → släpp `hero.mp4` → Commit till `main`
+4. Vercel bygger om automatiskt — videon är live inom ett par minuter
+
+## Rekommenderad komprimering (för snabb laddning)
+
+- 1080p, H.264 (MP4), utan ljudspår, mål: under ~15 MB
+- Med ffmpeg: `ffmpeg -i input.mp4 -an -vf scale=1920:-2 -c:v libx264 -crf 28 -preset slow -movflags +faststart hero.mp4`
+- `-movflags +faststart` är viktigt — videon börjar spela innan hela filen laddats
+- Max 100 MB (GitHubs filgräns), men håll den långt under för mobilbesökare


### PR DESCRIPTION
Heron spelar nu `/media/hero.mp4` automatiskt (loopad, ljudlös, playsinline). Tills filen laddats upp visas nuvarande hero-bild som poster — ingen visuell förändring.

Videofilen kan inte hämtas från Google Drive i den här miljön (nätverkspolicy) — uppladdningssteg och ffmpeg-komprimering dokumenterade i `bahkobyra/media/README.md`.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_