### PR TITLE
Lokala företag-positionering, ny hero-copy, GMB/SEO/Citations-steg + mobilfixar

### DIFF
--- a/bahkobyra/css/style.css
+++ b/bahkobyra/css/style.css
@@ -201,7 +201,7 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
 .hero-h1 .line{overflow:hidden;display:block}
 .hero-h1 .line > *{display:block;will-change:transform}
 .hero-h1{font-family:var(--display);font-weight:500;color:var(--paper);
-  font-size:clamp(2.5rem,6.4vw,5.8rem);line-height:1.02;letter-spacing:-.02em;margin-bottom:1.5rem}
+  font-size:clamp(2.1rem,6.4vw,5.8rem);line-height:1.04;letter-spacing:-.02em;margin-bottom:1.5rem}
 .hero-h1 .accent{font-style:italic;font-weight:400;
   background:linear-gradient(108deg,var(--gold-lt),var(--gold));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
 .hero-lede{font-size:clamp(.95rem,1.2vw,1.12rem);color:var(--paper-70);line-height:1.85;font-weight:300;max-width:52ch;margin:0 auto}
@@ -399,6 +399,11 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
 @media(max-width:860px){
   .nav{display:none}
   .burger{display:flex}
+  /* Process: pinned horisontell scroll ersätts av nativ svepning med snap */
+  .proc-track{overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;
+    scrollbar-width:none;padding-bottom:2.5rem}
+  .proc-track::-webkit-scrollbar{display:none}
+  .pstep{scroll-snap-align:center}
   .demo .wrap,.why .wrap{grid-template-columns:1fr}
   .audit{grid-template-columns:1fr}
   .foot-top{flex-direction:column;align-items:flex-start}

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Bahko Byrå | Hemsidor, SEO &amp; Google Ads för Svenska Kliniker</title>
-<meta name="description" content="Bahko Byrå hjälper svenska kliniker att synas på Google, få fler bokningar och växa online. Professionella hemsidor, Google Ads och SEO — anpassat för estetiska kliniker.">
+<title>Bahko Byrå | Hemsidor, SEO &amp; Google Ads för Lokala Företag</title>
+<meta name="description" content="Bahko Byrå hjälper lokala företag att synas på Google, få fler kunder och växa online. Professionella hemsidor, Google Ads och SEO — byggt för lokala marknader.">
 <meta name="robots" content="index, follow">
 <meta name="theme-color" content="#181C38">
 <link rel="canonical" href="https://www.bahkobyra.se/">
@@ -12,16 +12,16 @@
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.bahkobyra.se/">
-<meta property="og:title" content="Bahko Byrå | Hemsidor, SEO & Google Ads för Svenska Kliniker">
-<meta property="og:description" content="Bahko Byrå hjälper svenska kliniker att synas på Google, få fler bokningar och växa online. Professionella hemsidor, Google Ads och SEO.">
+<meta property="og:title" content="Bahko Byrå | Hemsidor, SEO & Google Ads för Lokala Företag">
+<meta property="og:description" content="Bahko Byrå hjälper lokala företag att synas på Google, få fler kunder och växa online. Professionella hemsidor, Google Ads och SEO.">
 <meta property="og:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
 <meta property="og:locale" content="sv_SE">
 <meta property="og:site_name" content="Bahko Byrå">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Bahko Byrå | Hemsidor, SEO & Google Ads för Svenska Kliniker">
-<meta name="twitter:description" content="Vi hjälper svenska kliniker att synas på Google, få fler bokningar och växa online.">
+<meta name="twitter:title" content="Bahko Byrå | Hemsidor, SEO & Google Ads för Lokala Företag">
+<meta name="twitter:description" content="Vi hjälper lokala företag att synas på Google, få fler kunder och växa online.">
 <meta name="twitter:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -42,7 +42,7 @@
   "logo": "https://www.bahkobyra.se/brand/BahkoStudio-removebg-preview.png",
   "image": "https://www.bahkobyra.se/brand/Bahkostudio.jpg",
   "email": "mathias@bahkobyra.se",
-  "description": "Digital byrå specialiserad på hemsidor, SEO och Google Ads för svenska kliniker och skönhetsföretag.",
+  "description": "Digital byrå specialiserad på hemsidor, SEO och Google Ads för lokala företag i Sverige.",
   "slogan": "Synlighet som säljer.",
   "priceRange": "$$",
   "areaServed": "SE",
@@ -51,9 +51,9 @@
   "contactPoint": { "@type": "ContactPoint", "contactType": "sales", "email": "mathias@bahkobyra.se", "areaServed": "SE", "availableLanguage": "Swedish" },
   "sameAs": [],
   "offers": [
-    { "@type": "Offer", "name": "Hemsida", "description": "Professionell hemsida för kliniker" },
-    { "@type": "Offer", "name": "Google Ads", "description": "Annonsering på Google riktad mot klinikpatienter" },
-    { "@type": "Offer", "name": "SEO", "description": "Sökmotoroptimering för svenska kliniker" }
+    { "@type": "Offer", "name": "Hemsida", "description": "Professionell hemsida för lokala företag" },
+    { "@type": "Offer", "name": "Google Ads", "description": "Annonsering på Google riktad mot lokala kunder" },
+    { "@type": "Offer", "name": "SEO", "description": "Lokal sökmotoroptimering för svenska företag" }
   ]
 }
 </script>
@@ -112,24 +112,24 @@
   <div class="hero-grain"></div>
 
   <div class="hero-inner">
-    <span class="hero-badge"><i></i> För kliniker &amp; lokala företag i Sverige</span>
+    <span class="hero-badge"><i></i> För lokala företag i Sverige</span>
     <h1 class="hero-h1">
       <span class="line"><span>Vi fyller din kalender</span></span>
       <span class="line"><span>med <span class="accent">nya kunder.</span></span></span>
     </h1>
-    <p class="hero-lede">Hemsidor som gör besökare till bokningar — och synlighet där dina kunder söker. Se videon nedan, den visar exakt hur vi gör.</p>
+    <p class="hero-lede">Är ditt företag osynligt på Google? Se den korta videon — den visar varför du inte ligger topp 3 när kunder i din stad söker.</p>
 
     <div class="hero-video">
       <iframe src="https://www.youtube-nocookie.com/embed/ZjvHsth4NJM?rel=0&amp;modestbranding=1&amp;playsinline=1&amp;color=white"
-        title="Så fyller vi din kalender med nya kunder — Bahko Byrå"
+        title="Därför syns inte ditt företag på Google — Bahko Byrå"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowfullscreen></iframe>
     </div>
 
     <div class="hero-ctas">
-      <a href="#kontakt" class="btn btn-gold magnetic" data-magnetic=".3"><span>Boka Gratis Samtal</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
+      <a href="/kliniker/gratis-guide.html" class="btn btn-gold magnetic" data-magnetic=".3"><span>Gratis Guide</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
     </div>
-    <p class="hero-micro">Gratis · 20 minuter · Inga förpliktelser</p>
+    <p class="hero-micro">3 steg för att växa på Google · 100% gratis · Inga krav</p>
   </div>
 
   <div class="scrollcue"><span class="ln"></span><span>Scrolla</span></div>
@@ -204,7 +204,7 @@
         <div class="demo-mock">
           <div class="demo-dots"><i></i><i></i><i></i></div>
           <div class="demo-bar a"></div><div class="demo-bar b"></div><div class="demo-bar c"></div><div class="demo-bar d"></div>
-          <div class="demo-lbl">Élara Klinik · Live Demo</div>
+          <div class="demo-lbl">Élara · Live Demo</div>
         </div>
       </div>
     </div>
@@ -248,8 +248,8 @@
         <span class="audit-badge">Tidsbegränsat erbjudande</span>
         <span class="audit-price"><s>799 kr</s> → <b>GRATIS</b></span>
       </div>
-      <h3>Få en gratis 10-punktsanalys<br>av er kliniksajt</h3>
-      <p>Vi granskar er webbplats och skickar en personlig rapport direkt till er inbox — mobilanpassning, SEO, bokningsflöde och mer. Svar inom 24h.</p>
+      <h3>Få en gratis 10-punktsanalys<br>av er hemsida</h3>
+      <p>Vi granskar er webbplats och skickar en personlig rapport direkt till er inbox — mobilanpassning, SEO, kontaktflöde och mer. Svar inom 24h.</p>
     </div>
     <a href="/kliniker/gratis-granskning.html" class="btn btn-gold magnetic" data-magnetic=".25"><span>Få gratis analys</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
   </div>
@@ -308,10 +308,10 @@
   <div class="foot-nl">
     <div class="foot-nl-copy">
       <h4>Ett konkret tillväxttips i månaden</h4>
-      <p>Hur kliniker syns högre på Google och får fler bokningar. Inget brus — avregistrera när du vill.</p>
+      <p>Hur lokala företag syns högre på Google och får fler kunder. Inget brus — avregistrera när du vill.</p>
     </div>
     <form class="foot-nl-form" id="nlform" action="https://formspree.io/f/mgonrnep" method="POST">
-      <input type="email" name="email" placeholder="du@dinklinik.se" required autocomplete="email" aria-label="Din e-post">
+      <input type="email" name="email" placeholder="du@dittforetag.se" required autocomplete="email" aria-label="Din e-post">
       <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px">
       <input type="hidden" name="_subject" value="Ny prenumerant – nyhetsbrev (footer bahkobyra.se)">
       <button class="btn btn-gold" type="submit"><span>Prenumerera</span></button>
@@ -335,7 +335,7 @@
   <div class="pop-card">
     <button class="pop-x" id="pop-x" aria-label="Stäng">×</button>
     <div class="pop-ey">Tidsbegränsat erbjudande</div>
-    <h3>Få en gratis analys av er kliniksajt</h3>
+    <h3>Få en gratis analys av er hemsida</h3>
     <p>Vi granskar er webbplats mot 10 punkter och skickar rapporten direkt till er inbox — inom 24h.</p>
     <div class="pop-prices">
       <div class="box old"><b>799 kr</b><small>ordinarie</small></div>

--- a/bahkobyra/kliniker/gratis-granskning.html
+++ b/bahkobyra/kliniker/gratis-granskning.html
@@ -3,16 +3,16 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gratis Webbplatsanalys för Kliniker | Bahko Byrå</title>
-<meta name="description" content="Få en gratis 10-punktsanalys av er kliniksajt. Vi granskar SEO, mobilanpassning, bokningsflöde och mer — helt gratis, utan krav.">
+<title>Gratis Webbplatsanalys för Lokala Företag | Bahko Byrå</title>
+<meta name="description" content="Få en gratis 10-punktsanalys av er hemsida. Vi granskar SEO, mobilanpassning, kontaktflöde och mer — helt gratis, utan krav.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://www.bahkobyra.se/kliniker/gratis-granskning.html">
 
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.bahkobyra.se/kliniker/gratis-granskning.html">
-<meta property="og:title" content="Gratis Webbplatsanalys för Kliniker | Bahko Byrå">
-<meta property="og:description" content="10-punktsanalys av er kliniksajt — SEO, mobilanpassning, bokningsflöde. Helt gratis, svar inom 24h.">
+<meta property="og:title" content="Gratis Webbplatsanalys för Lokala Företag | Bahko Byrå">
+<meta property="og:description" content="10-punktsanalys av er hemsida — SEO, mobilanpassning, kontaktflöde. Helt gratis, svar inom 24h.">
 <meta property="og:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
 <meta property="og:locale" content="sv_SE">
 
@@ -172,7 +172,7 @@ footer a:hover{color:var(--gold-dk)}
 <!-- HERO -->
 <section class="hero">
   <div class="hero-badge">Gratis — värde 799 kr · Svar inom 24h</div>
-  <h1 class="hero-title">Hur ser din kliniksajt<br>ut i <em>köparens ögon?</em></h1>
+  <h1 class="hero-title">Hur ser din hemsida<br>ut i <em>kundens ögon?</em></h1>
   <p class="hero-sub">Vi gör en 10-punktsanalys av er webbplats och skickar resultatet direkt till er — helt gratis, utan krav och utan säljpitch.</p>
   <div class="hero-stats">
     <div class="hero-stat">
@@ -195,13 +195,13 @@ footer a:hover{color:var(--gold-dk)}
 <!-- WHAT YOU GET -->
 <section class="section">
   <div class="eyebrow">Vad vi granskar</div>
-  <h2 class="section-title">10 punkter som avgör om er sajt<br>tappar patienter</h2>
+  <h2 class="section-title">10 punkter som avgör om er sajt<br>tappar kunder</h2>
   <div class="points-grid">
     <div class="point">
       <div class="point-num">01</div>
       <div class="point-body">
         <h4>Mobilanpassning</h4>
-        <p>70% av kliniksökningar sker på telefon. Fungerar er sajt perfekt på mobil?</p>
+        <p>De flesta lokala sökningar sker på telefon. Fungerar er sajt perfekt på mobil?</p>
       </div>
     </div>
     <div class="point">
@@ -215,28 +215,28 @@ footer a:hover{color:var(--gold-dk)}
       <div class="point-num">03</div>
       <div class="point-body">
         <h4>Lokal SEO & Google Maps</h4>
-        <p>Syns ni när folk söker "[behandling] [stad]"? Är er Google Business-profil komplett?</p>
+        <p>Syns ni när folk söker "[tjänst] [stad]"? Är er Google Företagsprofil komplett?</p>
       </div>
     </div>
     <div class="point">
       <div class="point-num">04</div>
       <div class="point-body">
-        <h4>Bokningsflöde</h4>
-        <p>Hur många klick krävs för att boka? Varje extra steg kostar bokningar.</p>
+        <h4>Boknings- &amp; kontaktflöde</h4>
+        <p>Hur många klick krävs för att boka eller begära offert? Varje extra steg kostar kunder.</p>
       </div>
     </div>
     <div class="point">
       <div class="point-num">05</div>
       <div class="point-body">
         <h4>Trustsignaler</h4>
-        <p>Certifikat, betyg och before/after-bilder — syns de tydligt? Förtroende avgör valet.</p>
+        <p>Certifikat, betyg och riktiga bilder på ert arbete — syns de tydligt? Förtroende avgör valet.</p>
       </div>
     </div>
     <div class="point">
       <div class="point-num">06</div>
       <div class="point-body">
         <h4>Sociala bevis</h4>
-        <p>Recensioner, antal behandlingar, nöjda patienter — visas det på er sajt?</p>
+        <p>Recensioner, genomförda uppdrag, nöjda kunder — visas det på er sajt?</p>
       </div>
     </div>
     <div class="point">
@@ -257,7 +257,7 @@ footer a:hover{color:var(--gold-dk)}
       <div class="point-num">09</div>
       <div class="point-body">
         <h4>Design & varumärke</h4>
-        <p>Speglar designen det er klinik faktiskt erbjuder? Professionellt = förtroende.</p>
+        <p>Speglar designen det ert företag faktiskt erbjuder? Professionellt = förtroende.</p>
       </div>
     </div>
     <div class="point">
@@ -281,7 +281,7 @@ footer a:hover{color:var(--gold-dk)}
       <div class="proc-n"><span>1</span></div>
       <div class="proc-body">
         <h4>Fyll i formuläret nedan</h4>
-        <p>Ange er kliniknamn, webbadress och e-post. Det tar under 60 sekunder.</p>
+        <p>Ange ert företagsnamn, webbadress och e-post. Det tar under 60 sekunder.</p>
       </div>
     </div>
     <div class="proc-step">
@@ -295,7 +295,7 @@ footer a:hover{color:var(--gold-dk)}
       <div class="proc-n"><span>3</span></div>
       <div class="proc-body">
         <h4>Rapporten landar i er inkorg</h4>
-        <p>Inom 24 timmar får ni en konkret lista med vad som fungerar och vad som kostar er patienter — utan säljpitch.</p>
+        <p>Inom 24 timmar får ni en konkret lista med vad som fungerar och vad som kostar er kunder — utan säljpitch.</p>
       </div>
     </div>
   </div>
@@ -315,23 +315,23 @@ footer a:hover{color:var(--gold-dk)}
           <input type="text" id="namn" name="namn" placeholder="Anna Svensson" required autocomplete="name">
         </div>
         <div class="field">
-          <label for="klinik">Klinikens namn</label>
-          <input type="text" id="klinik" name="klinik" placeholder="Luminos Klinik" required>
+          <label for="klinik">Företagets namn</label>
+          <input type="text" id="klinik" name="klinik" placeholder="Ditt Företag AB" required>
         </div>
       </div>
       <div class="field">
         <label for="webbplats">Webbadress</label>
-        <input type="url" id="webbplats" name="webbplats" placeholder="https://erkliniksajt.se" required autocomplete="url">
+        <input type="url" id="webbplats" name="webbplats" placeholder="https://dittforetag.se" required autocomplete="url">
       </div>
       <div class="field">
         <label for="email">Er e-post</label>
-        <input type="email" id="email" name="email" placeholder="hej@erkliniksajt.se" required autocomplete="email">
+        <input type="email" id="email" name="email" placeholder="hej@dittforetag.se" required autocomplete="email">
       </div>
       <div class="field">
         <label for="utmaning">Er största utmaning just nu <span style="text-transform:none;letter-spacing:.04em;opacity:.6">(valfritt)</span></label>
         <select id="utmaning" name="utmaning">
           <option value="">Välj…</option>
-          <option>Fler bokningar</option>
+          <option>Fler kunder &amp; bokningar</option>
           <option>Synas högre på Google</option>
           <option>Hemsidan känns gammal</option>
           <option>Vet inte — det är därför jag vill ha analysen</option>

--- a/bahkobyra/kliniker/gratis-guide.html
+++ b/bahkobyra/kliniker/gratis-guide.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gratis guide + video: 3 sätt att ranka högre på Google | Bahko Byrå</title>
-<meta name="description" content="Få Bahko Byrås gratisguide + en kort video som visar exakt hur din klinik rankar högre på Google och Google Maps — utan att betala för annonser. Direkt, gratis.">
+<meta name="description" content="Få Bahko Byrås gratisguide + en kort video som visar exakt hur ditt lokala företag rankar högre på Google och Google Maps — utan att betala för annonser. Direkt, gratis.">
 <meta name="robots" content="index, follow">
 <meta name="theme-color" content="#0c0a09">
 <link rel="canonical" href="https://www.bahkobyra.se/kliniker/gratis-guide.html">
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.bahkobyra.se/kliniker/gratis-guide.html">
 <meta property="og:title" content="Gratis guide + video: 3 sätt att ranka högre på Google">
-<meta property="og:description" content="Få guiden + en kort video som visar exakt hur du tar din klinik till topp 3 på Google. Gratis.">
+<meta property="og:description" content="Få guiden + en kort video som visar exakt hur du tar ditt företag till topp 3 på Google. Gratis.">
 <meta property="og:image" content="https://www.bahkobyra.se/brand/Bahkostudio.jpg">
 <meta property="og:locale" content="sv_SE">
 
@@ -136,7 +136,7 @@
   <div class="inner wrap">
     <span class="eyebrow">Gratis guide + video</span>
     <h1>3 sätt att ranka <em>högre</em> på Google — utan att betala för annonser</h1>
-    <p class="lede">Få vår gratisguide plus en kort video som visar <strong style="color:var(--text)">exakt</strong> hur du tar din klinik till topp 3 på Google och Google Maps. Inga tekniska kunskaper behövs.</p>
+    <p class="lede">Få vår gratisguide plus en kort video som visar <strong style="color:var(--text)">exakt</strong> hur du tar ditt lokala företag till topp 3 på Google och Google Maps. Inga tekniska kunskaper behövs.</p>
     <div class="vid-hint"><span class="pl">▶</span> Guide i text + ~4 min video</div>
 
     <!-- OPT-IN: capture via Formspree, reveal guide+video on success -->
@@ -150,7 +150,7 @@
         </div>
         <div class="field">
           <label for="g-epost">E-post</label>
-          <input type="email" id="g-epost" name="email" placeholder="du@dinklinik.se" required autocomplete="email">
+          <input type="email" id="g-epost" name="email" placeholder="du@dittforetag.se" required autocomplete="email">
         </div>
         <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px">
         <input type="hidden" name="_subject" value="Ny guide-nedladdning – lead magnet (gratis-guide)">
@@ -161,9 +161,9 @@
 
     <!-- visible teasers (bygger lust + SEO) -->
     <div class="teasers">
-      <div class="teaser"><span class="n">1</span><div><b>Gör din Google Företagsprofil komplett</b> — den största rankingfaktorn de flesta missar till hälften.</div></div>
-      <div class="teaser"><span class="n">2</span><div><b>Sätt recensioner i system</b> — så hamnar du över konkurrenten patienterna annars väljer.</div></div>
-      <div class="teaser"><span class="n">3</span><div><b>Lokala signaler &amp; NAP</b> — gör det glasklart för Google var och vad du är.</div></div>
+      <div class="teaser"><span class="n">1</span><div><b>Google Företagsprofil (GMB)</b> — den största lokala rankingfaktorn, som de flesta bara fyller i till hälften.</div></div>
+      <div class="teaser"><span class="n">2</span><div><b>On-page SEO</b> — rätt ord på rätt plats på din hemsida, så Google förstår vad du gör och var.</div></div>
+      <div class="teaser"><span class="n">3</span><div><b>Citations</b> — samma företagsuppgifter överallt på nätet. Konsekvens = förtroende hos Google.</div></div>
     </div>
   </div>
 </section>
@@ -176,7 +176,7 @@
     <div class="reveal-head">
       <span class="badge">✓ Upplåst — här är din guide + video</span>
       <h2>Så rankar du <em>högre</em> på Google</h2>
-      <p>Titta på videon först, läs sedan stegen. Börja med tips 1 redan idag.</p>
+      <p>Titta på videon först, läs sedan stegen. Börja med steg 1 redan idag.</p>
     </div>
 
     <!-- VIDEO -->
@@ -195,44 +195,44 @@
       </div>
     </div>
 
-    <!-- TIP 1 -->
+    <!-- STEG 1: GMB -->
     <article class="tip">
-      <div class="tip-n">Tips 1</div>
+      <div class="tip-n">Steg 1 · GMB-profil</div>
       <h3>Gör din Google Företagsprofil komplett — och välj rätt kategori</h3>
       <p>Profilen som visas i kartan är den enskilt största faktorn för var du hamnar lokalt. De flesta fyller i den till hälften och undrar sedan varför de ligger lågt.</p>
       <ul>
         <li>Logga in via <strong style="color:var(--text)">google.com/business</strong> (eller sök ditt företagsnamn → "Hantera").</li>
-        <li>Sätt <strong style="color:var(--text)">exakt rätt huvudkategori</strong> (t.ex. "Hudvårdsklinik", inte bara "Klinik"). Lägg till 1–2 relevanta till — sedan stopp.</li>
-        <li>Fyll i <strong style="color:var(--text)">allt</strong>: öppettider, tjänster med beskrivningar, attribut, bokningslänk och en beskrivning med din ort i.</li>
-        <li>Ladda upp minst 10 riktiga foton (lokal, team, behandlingar, före/efter).</li>
+        <li>Sätt <strong style="color:var(--text)">exakt rätt huvudkategori</strong> — den mest specifika för det ni gör, inte den breda. Lägg till 1–2 relevanta till — sedan stopp.</li>
+        <li>Fyll i <strong style="color:var(--text)">allt</strong>: öppettider, tjänster med beskrivningar, attribut, boknings-/offertlänk och en beskrivning med din ort i.</li>
+        <li>Ladda upp minst 10 riktiga foton (lokal, team, era jobb och resultat) — och posta något litet varje vecka.</li>
       </ul>
       <p class="win">Snabb vinst: en halvtom profil som blir 100 % ifylld rör sig ofta uppåt inom ett par veckor.</p>
     </article>
 
-    <!-- TIP 2 -->
+    <!-- STEG 2: ON-PAGE SEO -->
     <article class="tip">
-      <div class="tip-n">Tips 2</div>
-      <h3>Sätt recensioner i system</h3>
-      <p>Företaget med flest och färskast recensioner vinner nästan alltid — både Googles förtroende (ranking) och patientens (klicket). De flesta ber aldrig, eller för sällan.</p>
+      <div class="tip-n">Steg 2 · On-page SEO</div>
+      <h3>Rätt ord på rätt plats — på din egen hemsida</h3>
+      <p>Google läser din sajt för att förstå <em>vad</em> du gör och <em>var</em>. Står det inte tydligt — på rätt ställen — förlorar du mot konkurrenten där det gör det.</p>
       <ul>
-        <li>Skapa din recensionslänk i profilen och korta ner den så den är lätt att dela.</li>
-        <li>Be <strong style="color:var(--text)">varje</strong> nöjd kund samma dag — via SMS eller en QR-kod i receptionen. Ett klick för dem.</li>
-        <li>Svara på alla recensioner, även de sura. Lugnt och professionellt.</li>
-        <li>Mål: 1–2 nya recensioner i veckan, för alltid.</li>
+        <li>Sätt <strong style="color:var(--text)">tjänst + ort i sidtiteln och huvudrubriken (H1)</strong>: t.ex. "[Din tjänst] i [Din stad] – [Företagsnamn]".</li>
+        <li>Ge <strong style="color:var(--text)">varje huvudtjänst en egen sida</strong> med egen titel och rubrik — en sida kan inte ranka för allt.</li>
+        <li>Skriv en meta-beskrivning som säljer klicket: vad ni gör, var, och varför man ska välja er.</li>
+        <li>Snabb och mobilanpassad sajt + en inbäddad Google-karta på kontaktsidan.</li>
       </ul>
-      <p class="win">Snabb vinst: börja idag med dina tre senaste nöjda kunder.</p>
+      <p class="win">Snabb vinst: uppdatera startsidans titel och H1 med tjänst + ort — gjort på tio minuter.</p>
     </article>
 
-    <!-- TIP 3 -->
+    <!-- STEG 3: CITATIONS -->
     <article class="tip">
-      <div class="tip-n">Tips 3</div>
-      <h3>Få ort + tjänst på rätt ställen (lokala signaler &amp; NAP)</h3>
-      <p>Google måste förstå <em>vad</em> du gör och <em>var</em> du finns. Hjälp den genom att vara tydlig och konsekvent — på sajten och ute på nätet.</p>
+      <div class="tip-n">Steg 3 · Citations</div>
+      <h3>Samma uppgifter överallt — bygg dina citations</h3>
+      <p>En citation är varje plats på nätet där ditt företagsnamn, adress och telefon (<em>NAP</em>) nämns. Ju fler och ju mer konsekventa, desto mer litar Google på att du är den du säger.</p>
       <ul>
-        <li>Sätt din ort i sidtiteln och i huvudrubriken (H1): t.ex. "Hudvårdsklinik i Västerås – [Namn]".</li>
-        <li><strong style="color:var(--text)">NAP</strong> (namn, adress, telefon) ska se exakt likadana ut överallt: sajt, Google, Hitta, Eniro, Facebook.</li>
-        <li>Lägg upp företaget med samma uppgifter på Bing Places, Apple Business Connect och de svenska katalogerna.</li>
-        <li>Bädda in en Google-karta på din kontaktsida.</li>
+        <li><strong style="color:var(--text)">NAP ska se exakt likadan ut överallt</strong>: hemsidan, Google, Hitta, Eniro, Facebook. Minsta avvikelse förvirrar Google.</li>
+        <li>Lägg upp företaget med samma uppgifter på <strong style="color:var(--text)">Bing Places och Apple Business Connect</strong> — gratis och snabbt.</li>
+        <li>Lägg till branschkataloger och lokala företagsregister som är relevanta för just din bransch och ort.</li>
+        <li>Hitta gamla felaktiga uppgifter (gammalt nummer, gammal adress) och rätta dem.</li>
       </ul>
       <p class="win">Snabb vinst: rätta NAP så den är identisk på de fem viktigaste ställena — gjort på en timme.</p>
     </article>
@@ -240,7 +240,7 @@
     <!-- END CTA -->
     <div class="endcta">
       <h2>Vill du veta exakt var <em>du</em> ligger?</h2>
-      <p>Vi gör en gratis synlighetskoll: din position på kartan idag, vilka som ligger över dig och de tre sakerna vi skulle fixa först för just din klinik.</p>
+      <p>Vi gör en gratis synlighetskoll: din position på kartan idag, vilka som ligger över dig och de tre sakerna vi skulle fixa först för just ditt företag.</p>
       <a href="/#kontakt" class="btn"><span>Boka gratis samtal</span><svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
     </div>
   </div>


### PR DESCRIPTION
Hela publika sajten riktas nu mot **lokala företag** (inte kliniker/bygg):

**Copy** — `index.html`, `kliniker/gratis-guide.html`, `kliniker/gratis-granskning.html`: titlar, meta/OG, schema, hero-badge, analysbanner, popup, nyhetsbrev, formulärfält och placeholders genericiserade. Demo-etikett "Élara Klinik" → "Élara".

**Hero** — CTA: **Gratis Guide** (→ guiden). Ny lede: *"Är ditt företag osynligt på Google? Se den korta videon — den visar varför du inte ligger topp 3 när kunder i din stad söker."*

**Guidens 3 steg** — nu 1) Google Företagsprofil (GMB) 2) On-page SEO 3) Citations, med omskrivna teasers och tipsblock.

**Mobil** — riktig bugg fixad: "Hur vi jobbar"-korten var avklippta och onåbara under 861px (pinned scroll inaktiv + overflow hidden). Nu nativ svepning med scroll-snap. Hero-rubrikens min-storlek sänkt för smala skärmar.

Verifierat: `node --check`, smoke test 200 på alla sidor, inga klinik-/byggord kvar i synlig copy (endast URL-sökvägar).

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_