### PR TITLE
Bygg-demo: videoscrub rör sig nu med scrollen (mobil-fix)

### DIFF
--- a/.claude/skills/scroll-cinematic/SKILL.md
+++ b/.claude/skills/scroll-cinematic/SKILL.md
@@ -74,10 +74,17 @@ Klipp 2 "Steget in": samma params
 **Cloud-sandbox (Claude Code on the web — CDN-nedladdning blockerad, ffmpeg saknas):**
 Hotlinka MP4-url:erna i `<video muted playsinline preload="auto" crossorigin="anonymous" poster="<keyframe>">`
 och skrubba med `video.currentTime` — webbläsarens dekoder söker via range requests (cloudfront stödjer det).
-Detta är samma fallback som dokumenteras i video-to-website-skillens Troubleshooting. Mönstret finns färdigt
-i `bahkobyra/cloud/bygg/index.html` (funktionen `initCine`): pinned ScrollTrigger (`end:'+=300%'`, `scrub:.5`),
-seek-tröskel 0.02s, textrader med `data-in`/`data-out` som tonas manuellt i `onUpdate` (FADE=0.06),
-progress-bar `scaleX`.
+Mönstret finns färdigt i `bahkobyra/cloud/bygg/index.html` (funktionen `initCine`): pinned ScrollTrigger
+(`end:'+=300%'`, `scrub:.8`), textrader med `data-in`/`data-out` som tonas manuellt i `onUpdate` (FADE=0.06).
+
+**TRE OBLIGATORISKA delar för att currentTime-scrub ska fungera (lärdom 2026-06-11 — utan dem ser videon
+fryst ut på mobil):**
+1. **Gest-upplåsning:** mobila webbläsare avkodar inte video före `play()` i en användargest — kör
+   `play().then(pause)` på alla cine-videos vid första `touchstart/wheel/pointerdown/keydown` (`{once:true}`).
+2. **Seek-kö:** skicka ALDRIG ny `currentTime` innan förra seeken är klar. Håll `target` uppdaterad i
+   `onUpdate`, pumpa nästa seek i `'seeked'`-eventet. Att spamma seeks får mobildekodern att hacka/frysa.
+3. **Buffert-uppvärmning:** separat ScrollTrigger med `start:'top 150%'`, `once:true` som kör
+   `play().then(pause)` strax innan sektionen når skärmen.
 
 **Lokalt (ffmpeg finns + nätverk öppet):** ladda ner MP4:erna, extrahera frames och kör canvas-scrub
 enligt **video-to-website-skillen** (`fps≈12`, webp, 150-300 frames) — mjukare skrubb än currentTime.

--- a/bahkobyra/cloud/bygg/index.html
+++ b/bahkobyra/cloud/bygg/index.html
@@ -312,8 +312,23 @@ footer a{color:var(--amber-lt)}
     scrollTrigger:{trigger:'.work-grid',start:'top 84%'}});
 
   // ── SCROLL-CINEMATIC: pinna sektionen, skrubba videon med scrollen ──
-  // Sandbox-/cloud-vänlig variant: ingen frame-extraktion — webbläsarens egen
-  // dekoder söker i MP4:n via video.currentTime (kräver bara range requests på CDN).
+  // Videon rör sig I TAKT med scrollen (stannar du, stannar den).
+  // Tre saker krävs för att det ska funka överallt:
+  //  1) Gest-upplåsning — mobila webbläsare avkodar inte video före play() i en användargest
+  //  2) Seek-kö — skicka aldrig ny currentTime innan förra seeken är klar (annars fryser mobilen)
+  //  3) Buffert-uppvärmning strax innan sektionen syns
+  function unlockVideos(){
+    document.querySelectorAll('.cine video').forEach(v=>{
+      if(v.dataset.unlocked)return;
+      v.dataset.unlocked='1';
+      const p=v.play();
+      if(p&&p.then)p.then(()=>v.pause()).catch(()=>{delete v.dataset.unlocked;});
+      else v.pause();
+    });
+  }
+  ['touchstart','wheel','pointerdown','keydown'].forEach(ev=>
+    addEventListener(ev,unlockVideos,{once:true,passive:true}));
+
   function initCine(secId,vidId,progId,scrollLen){
     const sec=document.getElementById(secId),v=document.getElementById(vidId),prog=document.getElementById(progId);
     if(!sec||!v)return;
@@ -322,16 +337,30 @@ footer a{color:var(--amber-lt)}
       el,inP:parseFloat(el.dataset.in),outP:parseFloat(el.dataset.out)
     }));
     const FADE=.06;
-    let lastT=-1;
+
+    // Seek-kö: alltid mot SENASTE målet, en seek i taget
+    let target=0,seekBusy=false;
+    function pump(){
+      if(seekBusy||!(v.readyState>=1&&v.duration))return;
+      const t=Math.min(target*v.duration,v.duration-.05);
+      if(Math.abs(v.currentTime-t)<0.02)return;
+      seekBusy=true;
+      try{v.currentTime=t;}catch(e){seekBusy=false;}
+    }
+    v.addEventListener('seeked',()=>{seekBusy=false;pump();});
+    v.addEventListener('loadedmetadata',pump);
+
+    // Värm upp bufferten en halv viewport innan sektionen når skärmen
+    ScrollTrigger.create({trigger:sec,start:'top 150%',once:true,onEnter(){
+      const p=v.play();if(p&&p.then)p.then(()=>v.pause()).catch(()=>{});
+    }});
+
     ScrollTrigger.create({
-      trigger:sec,start:'top top',end:'+='+scrollLen,pin:true,scrub:.5,anticipatePin:1,invalidateOnRefresh:true,
+      trigger:sec,start:'top top',end:'+='+scrollLen,pin:true,scrub:.8,anticipatePin:1,invalidateOnRefresh:true,
       onUpdate(self){
         const p=self.progress;
-        // Videoscrub — kasta inte seek-anrop i onödan
-        if(v.readyState>=1&&v.duration){
-          const t=Math.min(p*v.duration,v.duration-.05);
-          if(Math.abs(t-lastT)>0.02){lastT=t;try{v.currentTime=t;}catch(e){}}
-        }
+        target=p;
+        pump();
         // Textrader: tona in/ut på progress-fönster
         lines.forEach(({el,inP,outP})=>{
           let o=0;


### PR DESCRIPTION
## Vad

Fixar att videon i bygg-demon **rör sig i takt med scrollen** (scroll-scrubbing som i referensexemplet) — tidigare kunde den se fryst ut, framför allt på mobil.

## Orsak + fix

1. **Gest-upplåsning** — mobila webbläsare (särskilt iOS Safari) vägrar avkoda/visa nya videoframes innan `play()` körts i en användargest. Nu låses båda cine-videorna upp med `play()→pause()` vid första touch/scroll.
2. **Seek-kö** — koden spammade `currentTime`-seeks på varje scroll-event, vilket får mobildekodern att hacka eller frysa. Nu skickas en seek i taget, alltid mot senaste scrollmålet, nästa pumpas i `seeked`-eventet.
3. **Buffert-uppvärmning** — varje cine-sektion förbuffras (`play()→pause()`) en halv viewport innan den når skärmen, så första seeken inte väntar på nätverket.
4. `scrub: .5 → .8` för mjukare koppling mellan scrollfart och videotid.

Lärdomarna är inskrivna som obligatoriska steg i scroll-cinematic-skillen så framtida demos får dem från start.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_