### PR TITLE
Bygg-demo: video-hero + gif-loopar istället för scroll-scrub

### DIFF
--- a/.claude/skills/scroll-cinematic/SKILL.md
+++ b/.claude/skills/scroll-cinematic/SKILL.md
@@ -15,13 +15,17 @@ Higgsfield MCP genererar klippen (1080p), scrollen skrubbar videon.
 
 ## Berättelsen (fast koncept — ändra inte strukturen)
 
-| Akt | Innehåll | Källa |
-|-----|----------|-------|
-| 0. Hero | Det utdömda huset, stillbild + premium-copy ("Vi ser huset ingen annan ser.") | Keyframe A |
-| 1. Förvandlingen | Pinned videoscrub: huset renoveras framför ögonen (3 textrader tonar in/ut) | Klipp 1 (A→B) |
-| — Mitt | Vision + Projektgrid (3 kort) — GRANIT-mallens mid-sections | Befintliga/nya bilder |
-| 2. Steget in | Pinned videoscrub: kameran glider fram, dörren öppnas, in i vardagsrummet ("Välkommen hem.") | Klipp 2 (B→C) |
-| 3. CTA | "Vad ser du i ditt hus?" + Bahko-modal med Cal.eu | Mall |
+| Sektion | Innehåll | Källa |
+|---------|----------|-------|
+| Hero | **Förvandlingsvideon som autoplay-loop (gif-känsla)** bakom hero-copy ("Vi ser huset ingen annan ser.") | Klipp 1 (A→B) |
+| Mitt | Vision + Projektgrid (3 kort) — GRANIT-mallens mid-sections | Befintliga/nya bilder |
+| Steget in | Fullskärms autoplay-loop: kameran glider in genom dörren, overlay "Välkommen hem." (data-reveal) | Klipp 2 (B→C) |
+| CTA | "Vad ser du i ditt hus?" + Bahko-modal med Cal.eu | Mall |
+
+**Videopresentation (beslut 2026-06-11): autoplay-loopar, INTE scroll-scrub.** `<video autoplay muted loop
+playsinline preload="auto" poster="<keyframe>">`. Ingen pin, ingen seek-logik. Lägg en gest-säkring
+(`touchstart/pointerdown` → `play()` på pausade videos) eftersom lågenergiläge på mobil kan blockera autoplay,
+och pausa looparna vid `prefers-reduced-motion`.
 
 **Mall/facit:** `bahkobyra/cloud/bygg/index.html` — kopiera den till `bahkobyra/cloud/[kund]/index.html`
 och byt varumärke (namn, färger om kunden har egna, copy, klipp). Behåll alltid: nav, vision,
@@ -69,26 +73,21 @@ Klipp 2 "Steget in": samma params
 - Får du en `preset_recommendation`-notis: kör om bokstavligt med `declined_preset_id` — vi vill ha exakt våra keyframes.
 - Polla med `job_display` tills `status: completed`; ta `results.rawUrl` (cloudfront-MP4).
 
-### 4. Scroll-implementation — två vägar beroende på miljö
+### 4. Videopresentation — autoplay-loop (standard)
 
-**Cloud-sandbox (Claude Code on the web — CDN-nedladdning blockerad, ffmpeg saknas):**
-Hotlinka MP4-url:erna i `<video muted playsinline preload="auto" crossorigin="anonymous" poster="<keyframe>">`
-och skrubba med `video.currentTime` — webbläsarens dekoder söker via range requests (cloudfront stödjer det).
-Mönstret finns färdigt i `bahkobyra/cloud/bygg/index.html` (funktionen `initCine`): pinned ScrollTrigger
-(`end:'+=300%'`, `scrub:.8`), textrader med `data-in`/`data-out` som tonas manuellt i `onUpdate` (FADE=0.06).
+Hotlinka MP4-url:erna (`results.rawUrl`) i `<video autoplay muted loop playsinline preload="auto"
+poster="<keyframe>">`. Hero = klipp 1 bakom hero-copy (med GSAP-parallax på videoelementet),
+"Steget in" = klipp 2 i en 100svh-sektion med overlay-rubrik. Mallen ligger i
+`bahkobyra/cloud/bygg/index.html`. Gest-säkring: vid första `touchstart/pointerdown`, `play()` på
+alla pausade videos (lågenergiläge på mobil blockerar ibland autoplay). `prefers-reduced-motion`:
+pausa looparna (postern står stilla).
 
-**TRE OBLIGATORISKA delar för att currentTime-scrub ska fungera (lärdom 2026-06-11 — utan dem ser videon
-fryst ut på mobil):**
-1. **Gest-upplåsning:** mobila webbläsare avkodar inte video före `play()` i en användargest — kör
-   `play().then(pause)` på alla cine-videos vid första `touchstart/wheel/pointerdown/keydown` (`{once:true}`).
-2. **Seek-kö:** skicka ALDRIG ny `currentTime` innan förra seeken är klar. Håll `target` uppdaterad i
-   `onUpdate`, pumpa nästa seek i `'seeked'`-eventet. Att spamma seeks får mobildekodern att hacka/frysa.
-3. **Buffert-uppvärmning:** separat ScrollTrigger med `start:'top 150%'`, `once:true` som kör
-   `play().then(pause)` strax innan sektionen når skärmen.
-
-**Lokalt (ffmpeg finns + nätverk öppet):** ladda ner MP4:erna, extrahera frames och kör canvas-scrub
-enligt **video-to-website-skillen** (`fps≈12`, webp, 150-300 frames) — mjukare skrubb än currentTime.
-Lägg frames i `bahkobyra/cloud/[kund]/frames/`.
+**Alternativ (endast om kunden uttryckligen ber om scroll-scrub):** `video.currentTime`-scrub kräver
+tre delar för att inte se fryst ut på mobil (lärdom 2026-06-11): (1) gest-upplåsning `play().then(pause)`
+vid första gest, (2) seek-kö — aldrig ny `currentTime` innan `'seeked'` har kommit, pumpa mot senaste
+målet, (3) buffert-uppvärmning via ScrollTrigger `start:'top 150%'`. Lokalt med ffmpeg: extrahera frames
+och kör canvas-scrub enligt video-to-website-skillen (mjukast). Historik: scrub-varianten finns i git
+(`git log bahkobyra/cloud/bygg/index.html`, commit "Videoscrub som faktiskt rör sig…").
 
 ### 5. Copy-regler
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Skills live in `.claude/skills/[skill-name]/SKILL.md`. Descriptions are always l
 
 - **skill-builder** — Guides building/auditing/optimizing skills. Runs Discovery Interview before creating. See `.claude/skills/skill-builder/reference.md`.
 - **video-to-website** — Converts a video into a scroll-driven animated website (FFmpeg + GSAP + Lenis + canvas).
-- **scroll-cinematic** — Bygg-demosajter enligt GRANIT-mallen med Higgsfield-genererad husförvandling som scroll-resa (gammalt hus → drömhus → kliv in). Kostar ~150 Higgsfield-credits/demo — körs aldrig utan beställning. Output: `bahkobyra/cloud/[kund]/index.html`.
+- **scroll-cinematic** — Bygg-demosajter enligt GRANIT-mallen med Higgsfield-genererad husförvandling (gammalt hus → drömhus → kliv in) som loopande videohero + "Välkommen hem"-loop (gif-känsla, ej scrub). Kostar ~150 Higgsfield-credits/demo — körs aldrig utan beställning. Output: `bahkobyra/cloud/[kund]/index.html`.
 - **excalidraw-diagram** — Generates editable Excalidraw diagrams, saves `.excalidraw` files.
 - **rapport** — Genererar konkurrensanalys, klientrapporter och lead-profiler. Exporterar till Google Docs/Sheets. Kräver `credentials.json` för Google OAuth. Export-verktyg: `tools/export_to_google_docs.js`.
 - **instagram-engine** — Producerar content-batchar (reels/carouseller/DM-cadence) för bygg/hantverk-nischen (@bahkostudio). Speglas i dashboardens Instagram-motor. Se `.claude/skills/instagram-engine/templates.md`.

--- a/bahkobyra/cloud/bygg/index.html
+++ b/bahkobyra/cloud/bygg/index.html
@@ -39,12 +39,12 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
   padding:.72rem 1.5rem;border-radius:4px;transition:transform .2s,box-shadow .3s;box-shadow:0 10px 28px -12px rgba(232,163,61,.55)}
 .nav-cta:hover{transform:translateY(-2px);box-shadow:0 16px 36px -12px rgba(232,163,61,.7)}
 
-/* ── HERO ── */
+/* ── HERO (förvandlingsvideon som loop, gif-känsla) ── */
 .hero{position:relative;min-height:100svh;display:flex;align-items:flex-end;overflow:hidden}
 .hero-bg{position:absolute;inset:0}
-.hero-bg img{width:100%;height:100%;object-fit:cover;will-change:transform}
+.hero-bg video{width:100%;height:100%;object-fit:cover;will-change:transform}
 .hero-bg::after{content:'';position:absolute;inset:0;background:
-  linear-gradient(180deg,rgba(11,11,13,.55) 0%,rgba(11,11,13,.15) 35%,rgba(11,11,13,.4) 70%,rgba(11,11,13,.97) 100%)}
+  linear-gradient(180deg,rgba(11,11,13,.55) 0%,rgba(11,11,13,.12) 35%,rgba(11,11,13,.38) 70%,rgba(11,11,13,.97) 100%)}
 .hero-inner{position:relative;z-index:2;width:100%;padding:0 clamp(1.2rem,4vw,3rem) clamp(3rem,7vh,5.5rem)}
 .hero-kicker{font-size:.68rem;font-weight:600;letter-spacing:.34em;text-transform:uppercase;color:var(--amber-lt);margin-bottom:1.1rem;display:flex;align-items:center;gap:.8rem}
 .hero-kicker::before{content:'';width:34px;height:2px;background:var(--grad)}
@@ -59,18 +59,6 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .scrollcue i{display:block;width:1px;height:44px;background:var(--line);position:relative;overflow:hidden}
 .scrollcue i::after{content:'';position:absolute;inset:-100% 0 auto;height:100%;background:var(--amber);animation:cue 2.2s var(--ease) infinite}
 @keyframes cue{0%{top:-100%}55%{top:0}100%{top:100%}}
-
-/* ── CINE (scroll-cinematic videoscrub) ── */
-.cine{position:relative;height:100svh;overflow:hidden;background:var(--bg)}
-.cine video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
-.cine::after{content:'';position:absolute;inset:0;pointer-events:none;background:
-  linear-gradient(180deg,rgba(11,11,13,.45) 0%,transparent 22%,transparent 72%,rgba(11,11,13,.55) 100%)}
-.cine-line{position:absolute;inset:0;z-index:3;display:grid;place-items:center;text-align:center;padding:0 5vw;opacity:0;will-change:opacity,transform}
-.cine-line h2{font-family:var(--disp);font-weight:900;font-size:clamp(2.2rem,7.8vw,6.8rem);line-height:1;text-transform:uppercase;letter-spacing:-.01em;
-  text-shadow:0 6px 40px rgba(0,0,0,.55)}
-.cine-line .sm{display:block;font-family:var(--sans);font-weight:500;font-size:clamp(.68rem,1vw,.85rem);letter-spacing:.3em;color:var(--amber-lt);margin-bottom:1rem;text-shadow:none}
-.cine-progress{position:absolute;left:50%;bottom:2rem;transform:translateX(-50%);z-index:3;width:min(200px,40vw);height:2px;background:var(--line);border-radius:2px;overflow:hidden}
-.cine-progress i{display:block;height:100%;width:100%;background:var(--grad);transform-origin:left;transform:scaleX(0)}
 
 /* ── VISION ── */
 .vision{padding:clamp(6rem,14vw,11rem) clamp(1.2rem,4vw,3rem);max-width:1050px;margin:0 auto;text-align:center}
@@ -92,6 +80,16 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .wc-tag{font-size:.58rem;font-weight:700;letter-spacing:.22em;text-transform:uppercase;color:var(--amber-lt)}
 .wc-body h3{font-family:var(--disp);font-weight:800;font-size:1.3rem;margin:.3rem 0 .25rem}
 .wc-body p{font-size:.78rem;color:var(--muted)}
+
+/* ── CINE (videoloop med text, gif-känsla) ── */
+.cine{position:relative;height:100svh;overflow:hidden;background:var(--bg)}
+.cine video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
+.cine::after{content:'';position:absolute;inset:0;pointer-events:none;background:
+  linear-gradient(180deg,rgba(11,11,13,.5) 0%,transparent 25%,transparent 70%,rgba(11,11,13,.6) 100%)}
+.cine-caption{position:absolute;inset:0;z-index:3;display:grid;place-items:center;text-align:center;padding:0 5vw}
+.cine-caption h2{font-family:var(--disp);font-weight:900;font-size:clamp(2.2rem,7.8vw,6.8rem);line-height:1;text-transform:uppercase;letter-spacing:-.01em;
+  text-shadow:0 6px 40px rgba(0,0,0,.55)}
+.cine-caption .sm{display:block;font-family:var(--sans);font-weight:500;font-size:clamp(.68rem,1vw,.85rem);letter-spacing:.3em;color:var(--amber-lt);margin-bottom:1rem;text-shadow:none}
 
 /* ── CTA ── */
 .cta{padding:clamp(6rem,13vw,10rem) clamp(1.2rem,4vw,3rem);text-align:center;position:relative;overflow:hidden}
@@ -138,9 +136,6 @@ footer a{color:var(--amber-lt)}
 }
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
-  .cine-line{opacity:1!important;position:relative;height:auto;padding:3rem 5vw}
-  .cine{height:auto;min-height:60svh}
-  .cine-progress{display:none}
   .hero h1 .row>span{transform:none!important}
 }
 </style>
@@ -152,9 +147,13 @@ footer a{color:var(--amber-lt)}
   <a class="nav-cta" href="#" onclick="openModal();return false">Begär offert</a>
 </nav>
 
-<!-- HERO — Akt 0: det utdömda huset -->
+<!-- HERO — förvandlingsvideon loopar som en gif: gammalt hus → drömhus -->
 <header class="hero">
-  <div class="hero-bg"><img id="hero-img" src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182550_1cb0eee4-3864-454a-abde-ddb5b00bd1f7.png" alt="" fetchpriority="high"></div>
+  <div class="hero-bg">
+    <video id="hero-vid" autoplay muted loop playsinline preload="auto"
+      poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182550_1cb0eee4-3864-454a-abde-ddb5b00bd1f7.png"
+      src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182857_9ce4a497-1a91-433a-b04a-392b167a726b.mp4"></video>
+  </div>
   <div class="hero-inner">
     <div class="hero-kicker">Bygg &amp; Totalrenovering · Mälardalen</div>
     <h1>
@@ -168,19 +167,8 @@ footer a{color:var(--amber-lt)}
       <div class="hm"><b>4.9 ★</b><span>Snittbetyg</span></div>
     </div>
   </div>
-  <div class="scrollcue">Scrolla — se förvandlingen <i></i></div>
+  <div class="scrollcue">Scrolla <i></i></div>
 </header>
-
-<!-- AKT 1 — FÖRVANDLINGEN (videoscrub: gammalt hus → drömhus) -->
-<section class="cine" id="cine1">
-  <video id="vid1" muted playsinline preload="auto" crossorigin="anonymous"
-    poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182550_1cb0eee4-3864-454a-abde-ddb5b00bd1f7.png"
-    src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182857_9ce4a497-1a91-433a-b04a-392b167a726b.mp4"></video>
-  <div class="cine-line" data-in="0.04" data-out="0.30"><h2><span class="sm">01 — Samma hus</span>Vi river inte<br>drömmar.</h2></div>
-  <div class="cine-line" data-in="0.38" data-out="0.64"><h2><span class="sm">02 — Förvandlingen</span>Vi bygger<br><span class="grad-text">fram dem.</span></h2></div>
-  <div class="cine-line" data-in="0.74" data-out="1.01"><h2><span class="sm">03 — Resultatet</span>Från utdömt<br>till <span class="grad-text">drömhus.</span></h2></div>
-  <div class="cine-progress"><i id="prog1"></i></div>
-</section>
 
 <!-- VISION -->
 <section class="vision" id="vision">
@@ -222,14 +210,14 @@ footer a{color:var(--amber-lt)}
   </div>
 </section>
 
-<!-- AKT 2 — STEGET IN (videoscrub: genom dörren in i drömhuset) -->
+<!-- STEGET IN — videoloop som en gif: genom dörren in i drömhuset -->
 <section class="cine" id="cine2">
-  <video id="vid2" muted playsinline preload="auto" crossorigin="anonymous"
+  <video id="vid2" autoplay muted loop playsinline preload="metadata"
     poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182740_5c48f715-f0c5-4357-9d90-7e9f50c4a596.png"
     src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182942_0a03fd06-ff6d-4bca-a454-1e2ff82f88f0.mp4"></video>
-  <div class="cine-line" data-in="0.05" data-out="0.32"><h2><span class="sm">Sista steget</span>Öppna<br>dörren.</h2></div>
-  <div class="cine-line" data-in="0.72" data-out="1.01"><h2><span class="sm">GRANIT Bygg &amp; Entreprenad</span>Välkommen<br><span class="grad-text">hem.</span></h2></div>
-  <div class="cine-progress"><i id="prog2"></i></div>
+  <div class="cine-caption">
+    <h2 data-reveal><span class="sm">GRANIT Bygg &amp; Entreprenad</span>Välkommen<br><span class="grad-text">hem.</span></h2>
+  </div>
 </section>
 
 <!-- CTA -->
@@ -268,6 +256,19 @@ footer a{color:var(--amber-lt)}
 (function(){
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Autoplay-säkring: vissa mobillägen (lågenergi) blockerar autoplay tills första gest
+  function kickVideos(){
+    document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});
+  }
+  addEventListener('touchstart',kickVideos,{once:true,passive:true});
+  addEventListener('pointerdown',kickVideos,{once:true,passive:true});
+
+  if(reduce){
+    // Reduced motion: pausa looparna, postern/första framen står stilla
+    document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
+  }
+
   if(typeof gsap==='undefined')return;
   gsap.registerPlugin(ScrollTrigger);
 
@@ -281,11 +282,7 @@ footer a{color:var(--amber-lt)}
   // Nav
   addEventListener('scroll',()=>document.getElementById('nav').classList.toggle('scrolled',scrollY>60),{passive:true});
 
-  if(reduce){
-    // Reduced motion: spela videorna som stillsamma loopar i stället för scrub
-    document.querySelectorAll('.cine video').forEach(v=>{v.loop=true;v.autoplay=true;v.play().catch(()=>{});});
-    return;
-  }
+  if(reduce)return;
 
   // Hero-entré
   gsap.set('.hero h1 .row>span',{yPercent:115});
@@ -297,8 +294,8 @@ footer a{color:var(--amber-lt)}
     .to('.hero-meta',{opacity:1,y:0,duration:.8,ease:'power3.out'},'-=.55')
     .to('.scrollcue',{opacity:1,y:0,duration:.7},'-=.4');
 
-  // Hero-parallax
-  gsap.to('#hero-img',{yPercent:14,scale:1.06,ease:'none',
+  // Hero-parallax på videon
+  gsap.to('#hero-vid',{yPercent:14,scale:1.06,ease:'none',
     scrollTrigger:{trigger:'.hero',start:'top top',end:'bottom top',scrub:true}});
 
   // Reveals
@@ -310,75 +307,6 @@ footer a{color:var(--amber-lt)}
   // Projektkort
   gsap.fromTo('[data-card]',{y:70,opacity:0,scale:.95},{y:0,opacity:1,scale:1,duration:1.1,ease:'expo.out',stagger:.12,
     scrollTrigger:{trigger:'.work-grid',start:'top 84%'}});
-
-  // ── SCROLL-CINEMATIC: pinna sektionen, skrubba videon med scrollen ──
-  // Videon rör sig I TAKT med scrollen (stannar du, stannar den).
-  // Tre saker krävs för att det ska funka överallt:
-  //  1) Gest-upplåsning — mobila webbläsare avkodar inte video före play() i en användargest
-  //  2) Seek-kö — skicka aldrig ny currentTime innan förra seeken är klar (annars fryser mobilen)
-  //  3) Buffert-uppvärmning strax innan sektionen syns
-  function unlockVideos(){
-    document.querySelectorAll('.cine video').forEach(v=>{
-      if(v.dataset.unlocked)return;
-      v.dataset.unlocked='1';
-      const p=v.play();
-      if(p&&p.then)p.then(()=>v.pause()).catch(()=>{delete v.dataset.unlocked;});
-      else v.pause();
-    });
-  }
-  ['touchstart','wheel','pointerdown','keydown'].forEach(ev=>
-    addEventListener(ev,unlockVideos,{once:true,passive:true}));
-
-  function initCine(secId,vidId,progId,scrollLen){
-    const sec=document.getElementById(secId),v=document.getElementById(vidId),prog=document.getElementById(progId);
-    if(!sec||!v)return;
-    v.pause();
-    const lines=Array.from(sec.querySelectorAll('.cine-line')).map(el=>({
-      el,inP:parseFloat(el.dataset.in),outP:parseFloat(el.dataset.out)
-    }));
-    const FADE=.06;
-
-    // Seek-kö: alltid mot SENASTE målet, en seek i taget
-    let target=0,seekBusy=false;
-    function pump(){
-      if(seekBusy||!(v.readyState>=1&&v.duration))return;
-      const t=Math.min(target*v.duration,v.duration-.05);
-      if(Math.abs(v.currentTime-t)<0.02)return;
-      seekBusy=true;
-      try{v.currentTime=t;}catch(e){seekBusy=false;}
-    }
-    v.addEventListener('seeked',()=>{seekBusy=false;pump();});
-    v.addEventListener('loadedmetadata',pump);
-
-    // Värm upp bufferten en halv viewport innan sektionen når skärmen
-    ScrollTrigger.create({trigger:sec,start:'top 150%',once:true,onEnter(){
-      const p=v.play();if(p&&p.then)p.then(()=>v.pause()).catch(()=>{});
-    }});
-
-    ScrollTrigger.create({
-      trigger:sec,start:'top top',end:'+='+scrollLen,pin:true,scrub:.8,anticipatePin:1,invalidateOnRefresh:true,
-      onUpdate(self){
-        const p=self.progress;
-        target=p;
-        pump();
-        // Textrader: tona in/ut på progress-fönster
-        lines.forEach(({el,inP,outP})=>{
-          let o=0;
-          if(p>=inP&&p<=outP){
-            if(p<inP+FADE)o=(p-inP)/FADE;
-            else if(p>outP-FADE)o=(outP-p)/FADE;
-            else o=1;
-          }
-          o=Math.max(0,Math.min(1,o));
-          el.style.opacity=o;
-          el.style.transform=`scale(${.96+.04*o})`;
-        });
-        if(prog)prog.style.transform=`scaleX(${p})`;
-      }
-    });
-  }
-  initCine('cine1','vid1','prog1','320%');
-  initCine('cine2','vid2','prog2','300%');
 
   setTimeout(()=>ScrollTrigger.refresh(),400);
 })();


### PR DESCRIPTION
## Vad

Bygg-demon omgjord enligt beställning:

1. **Stillbilds-heron borttagen** — förvandlingsvideon (gammalt hus → drömhus) är nu själva heron och loopar som en gif bakom GRANIT-copyn, med subtil parallax.
2. **Båda videorna autoplay-loopar** — ingen scroll-scrubbing. "Steget in"-klippet loopar i en egen fullskärmssektion med "Välkommen hem."-reveal.
3. All pin-/scrub-/seek-logik borttagen (−141 rader). Kvar: gest-säkring som kickar igång autoplay om mobilens lågenergiläge blockerat den, och paus av looparna vid `prefers-reduced-motion`.

Skill och CLAUDE.md uppdaterade: autoplay-loop är nu mallens standard för bygg-demos; scrub-varianten finns dokumenterad som tillval (och i git-historiken).

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_