### PR TITLE
Bygg-demo i Élara-strukturen: full scroll-koreografi + gif-loopar

### DIFF
--- a/.claude/skills/scroll-cinematic/SKILL.md
+++ b/.claude/skills/scroll-cinematic/SKILL.md
@@ -15,17 +15,24 @@ Higgsfield MCP genererar klippen (1080p), scrollen skrubbar videon.
 
 ## Berättelsen (fast koncept — ändra inte strukturen)
 
-| Sektion | Innehåll | Källa |
-|---------|----------|-------|
-| Hero | **Förvandlingsvideon som autoplay-loop (gif-känsla)** bakom hero-copy ("Vi ser huset ingen annan ser.") | Klipp 1 (A→B) |
-| Mitt | Vision + Projektgrid (3 kort) — GRANIT-mallens mid-sections | Befintliga/nya bilder |
-| Steget in | Fullskärms autoplay-loop: kameran glider in genom dörren, overlay "Välkommen hem." (data-reveal) | Klipp 2 (B→C) |
-| CTA | "Vad ser du i ditt hus?" + Bahko-modal med Cal.eu | Mall |
+**Strukturen = Élara-koreografin** (`bahkobyra/cloud/index.html`) — det är ALLTID den vi använder för
+kunddemos — med Higgsfield-gif:arna i stället för ambient-canvas. Facit för bygg:
+`bahkobyra/cloud/bygg/index.html`.
 
-**Videopresentation (beslut 2026-06-11): autoplay-loopar, INTE scroll-scrub.** `<video autoplay muted loop
-playsinline preload="auto" poster="<keyframe>">`. Ingen pin, ingen seek-logik. Lägg en gest-säkring
-(`touchstart/pointerdown` → `play()` på pausade videos) eftersom lågenergiläge på mobil kan blockera autoplay,
-och pausa looparna vid `prefers-reduced-motion`.
+| Del | Innehåll |
+|-----|----------|
+| Loader | Varumärke + progressbar (simulerad, snabb) |
+| Header | Fixed med nav-länkar + CTA-knapp; hamburger + helskärms-mobilnav under 768px |
+| Hero (100svh) | **Förvandlingsvideon som autoplay-loop (gif)** bakom ordvis staggad rubrik (`.word`, shimmer-accent), tagline, scroll-indikator. Heron tonar ut när scrollen börjar |
+| Fast videolager | **"Steget in"-loopen fixed bakom alla sektioner**, avtäcks med circle-wipe (`clip-path:circle`) när heron lämnar — nedtonad (brightness ~.62 + vinjett) för läsbarhet |
+| Scroll-container (900vh / 620vh mobil) | Absolut positionerade sektioner på progress-fönster (`data-enter`/`data-leave`), VARIERADE entréer — aldrig samma två gånger i rad: slide-left → fade-up → stagger-up → slide-right → stagger-up → scale-up |
+| Sektionerna | 001 Filosofi (sidoställd) · 002 **Före/efter-slider med keyframes A/B** (scroll-avtäckning + drag) · 003 Projektgrid (3 kort) · 004 Tjänstelista · 005 Stats med räknare som tickar upp · CTA med `data-persist="true"` |
+| Övrigt | Marquee i jättetext (outlined, xPercent på scroll) · dark overlay-fönster över projekt+stats · flytande offert-knapp efter 60 % viewport · Bahko-modal (Cal.eu) |
+
+**Videopresentation: autoplay-loopar (gif-känsla), INTE scroll-scrub.** `<video autoplay muted loop
+playsinline preload="auto" poster="<keyframe>">`. Gest-säkring (`touchstart/pointerdown` → `play()` på
+pausade videos) för lågenergiläge, och `prefers-reduced-motion`: pausa videos, döda loadern, gör
+sektionerna statiska (CSS: `#scroll-container{height:auto}`, `.scroll-section{position:static;opacity:1}`).
 
 **Mall/facit:** `bahkobyra/cloud/bygg/index.html` — kopiera den till `bahkobyra/cloud/[kund]/index.html`
 och byt varumärke (namn, färger om kunden har egna, copy, klipp). Behåll alltid: nav, vision,

--- a/bahkobyra/cloud/bygg/index.html
+++ b/bahkobyra/cloud/bygg/index.html
@@ -10,226 +10,420 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://d8j0ntlcm91z4.cloudfront.net" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=Archivo+Expanded:wght@600;700;800;900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;500;600;700;800;900&family=Archivo+Expanded:wght@600;700;800;900&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root{
   --bg:#0B0B0D; --bg2:#121215; --card:#17171B;
-  --text:#F2EFE9; --muted:rgba(242,239,233,.6); --dim:rgba(242,239,233,.38);
+  --text:#F2EFE9; --muted:rgba(242,239,233,.62); --dim:rgba(242,239,233,.4);
   --amber:#E8A33D; --amber-lt:#F6C76B; --amber-dk:#B97A1E;
-  --steel:#8FA3B8; --line:rgba(242,239,233,.1);
+  --line:rgba(242,239,233,.1);
   --grad:linear-gradient(100deg,var(--amber-lt) 0%,var(--amber) 45%,#D96E30 100%);
   --sans:'Archivo',system-ui,sans-serif; --disp:'Archivo Expanded','Archivo',sans-serif;
   --ease:cubic-bezier(.22,1,.36,1);
 }
 html{background:var(--bg);scroll-behavior:auto}
-body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+body{background:var(--bg);color:var(--text);font-family:var(--sans);overflow-x:hidden;-webkit-font-smoothing:antialiased;line-height:1.6}
 a{color:inherit;text-decoration:none}
 button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 ::selection{background:var(--amber);color:#16120A}
 .grad-text{background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
 
-/* ── NAV ── */
-.nav{position:fixed;top:0;left:0;right:0;z-index:100;display:flex;align-items:center;justify-content:space-between;
-  padding:1.2rem clamp(1.2rem,4vw,3rem);transition:background .4s,border-color .4s;border-bottom:1px solid transparent}
-.nav.scrolled{background:rgba(11,11,13,.82);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom-color:var(--line)}
-.logo{font-family:var(--disp);font-weight:900;font-size:1.05rem;letter-spacing:.18em;text-transform:uppercase}
-.logo em{font-style:normal;color:var(--amber)}
-.nav-cta{font-size:.72rem;font-weight:700;letter-spacing:.14em;text-transform:uppercase;background:var(--grad);color:#16120A;
-  padding:.72rem 1.5rem;border-radius:4px;transition:transform .2s,box-shadow .3s;box-shadow:0 10px 28px -12px rgba(232,163,61,.55)}
-.nav-cta:hover{transform:translateY(-2px);box-shadow:0 16px 36px -12px rgba(232,163,61,.7)}
+/* ===== LOADER ===== */
+#loader{position:fixed;inset:0;z-index:9999;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center;transition:opacity .6s ease,visibility .6s ease}
+#loader.hidden{opacity:0;visibility:hidden;pointer-events:none}
+.loader-brand{font-family:var(--disp);font-size:clamp(1.6rem,4.5vw,3rem);font-weight:900;letter-spacing:.25em;margin-bottom:3rem;text-transform:uppercase}
+.loader-brand em{font-style:normal;color:var(--amber)}
+#loader-bar-wrap{width:min(300px,60vw);height:1px;background:rgba(232,163,61,.2);overflow:hidden}
+#loader-bar{width:0%;height:100%;background:var(--grad);transition:width .3s ease}
+#loader-percent{font-size:.72rem;letter-spacing:.25em;color:var(--dim);margin-top:1.2rem;font-weight:400}
 
-/* ── HERO (förvandlingsvideon som loop, gif-känsla) ── */
-.hero{position:relative;min-height:100svh;display:flex;align-items:flex-end;overflow:hidden}
-.hero-bg{position:absolute;inset:0}
-.hero-bg video{width:100%;height:100%;object-fit:cover;will-change:transform}
-.hero-bg::after{content:'';position:absolute;inset:0;background:
-  linear-gradient(180deg,rgba(11,11,13,.55) 0%,rgba(11,11,13,.12) 35%,rgba(11,11,13,.38) 70%,rgba(11,11,13,.97) 100%)}
-.hero-inner{position:relative;z-index:2;width:100%;padding:0 clamp(1.2rem,4vw,3rem) clamp(3rem,7vh,5.5rem)}
-.hero-kicker{font-size:.68rem;font-weight:600;letter-spacing:.34em;text-transform:uppercase;color:var(--amber-lt);margin-bottom:1.1rem;display:flex;align-items:center;gap:.8rem}
-.hero-kicker::before{content:'';width:34px;height:2px;background:var(--grad)}
-.hero h1{font-family:var(--disp);font-weight:900;font-size:clamp(2.7rem,9.5vw,8.5rem);line-height:.95;letter-spacing:-.015em;text-transform:uppercase}
-.hero h1 .row{display:block;overflow:hidden}
-.hero h1 .row>span{display:block;will-change:transform}
-.hero-sub{max-width:50ch;color:var(--muted);font-size:clamp(.95rem,1.2vw,1.1rem);margin-top:1.4rem;font-weight:400}
-.hero-meta{display:flex;gap:2.2rem;margin-top:2rem;flex-wrap:wrap}
-.hm b{font-family:var(--disp);font-weight:800;font-size:1.25rem;display:block;color:var(--amber-lt)}
-.hm span{font-size:.64rem;letter-spacing:.2em;text-transform:uppercase;color:var(--dim)}
-.scrollcue{position:absolute;right:clamp(1.2rem,4vw,3rem);bottom:2.4rem;z-index:2;display:flex;align-items:center;gap:.7rem;color:var(--dim);font-size:.6rem;letter-spacing:.28em;text-transform:uppercase}
-.scrollcue i{display:block;width:1px;height:44px;background:var(--line);position:relative;overflow:hidden}
-.scrollcue i::after{content:'';position:absolute;inset:-100% 0 auto;height:100%;background:var(--amber);animation:cue 2.2s var(--ease) infinite}
-@keyframes cue{0%{top:-100%}55%{top:0}100%{top:100%}}
+/* ===== HEADER ===== */
+.site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1.6rem,env(safe-area-inset-top)) clamp(1.2rem,4vw,3rem) 1.6rem;display:flex;justify-content:space-between;align-items:center;transition:background .4s,border-color .4s;border-bottom:1px solid transparent}
+.site-header.scrolled{background:rgba(11,11,13,.82);backdrop-filter:blur(18px) saturate(1.2);-webkit-backdrop-filter:blur(18px) saturate(1.2);border-bottom-color:var(--line)}
+.header-logo{font-family:var(--disp);font-weight:900;font-size:1.05rem;letter-spacing:.18em;text-transform:uppercase}
+.header-logo em{font-style:normal;color:var(--amber)}
+.header-nav{display:flex;gap:2.4rem;align-items:center}
+.header-nav a{position:relative;font-size:.68rem;font-weight:600;letter-spacing:.2em;text-transform:uppercase;opacity:.75;transition:opacity .3s,color .3s}
+.header-nav a::after{content:'';position:absolute;left:0;bottom:-5px;height:1px;width:0;background:var(--amber);transition:width .35s var(--ease)}
+.header-nav a:hover{opacity:1;color:var(--amber-lt)}
+.header-nav a:hover::after{width:100%}
+.header-nav .nav-cta{opacity:1;background:var(--grad);color:#16120A;padding:.68rem 1.4rem;border-radius:4px;font-weight:700;box-shadow:0 10px 28px -12px rgba(232,163,61,.55);transition:transform .2s,box-shadow .3s}
+.header-nav .nav-cta::after{display:none}
+.header-nav .nav-cta:hover{transform:translateY(-2px);color:#16120A;box-shadow:0 16px 36px -12px rgba(232,163,61,.7)}
 
-/* ── VISION ── */
-.vision{padding:clamp(6rem,14vw,11rem) clamp(1.2rem,4vw,3rem);max-width:1050px;margin:0 auto;text-align:center}
-.vision h2{font-family:var(--disp);font-weight:800;font-size:clamp(1.7rem,4.2vw,3.4rem);line-height:1.18;letter-spacing:-.01em}
-.vision h2 em{font-style:normal;color:var(--amber)}
-.vision p{max-width:62ch;margin:1.8rem auto 0;color:var(--muted);font-size:clamp(.95rem,1.15vw,1.08rem)}
+/* Hamburger + mobilnav */
+.hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:10px;margin:-10px;z-index:200}
+.hamburger span{display:block;width:22px;height:1.5px;background:var(--text);transition:all .3s ease}
+.hamburger.open span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger.open span:nth-child(2){opacity:0}
+.hamburger.open span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-nav{position:fixed;inset:0;background:rgba(11,11,13,.96);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;opacity:0;visibility:hidden;transition:all .4s ease}
+.mobile-nav.open{opacity:1;visibility:visible}
+.mobile-nav a{font-family:var(--disp);font-size:2rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase;opacity:.8;transition:opacity .3s,color .3s}
+.mobile-nav a:hover{opacity:1;color:var(--amber)}
 
-/* ── PROJEKT ── */
-.work{padding:0 clamp(1.2rem,4vw,3rem) clamp(5rem,10vw,8rem);max-width:1320px;margin:0 auto}
-.work-head{display:flex;align-items:flex-end;justify-content:space-between;gap:1.5rem;flex-wrap:wrap;margin-bottom:2.4rem}
-.work-head h2{font-family:var(--disp);font-weight:900;font-size:clamp(1.9rem,4.6vw,3.6rem);text-transform:uppercase;letter-spacing:-.01em;line-height:1.05}
-.work-head p{color:var(--dim);font-size:.85rem;max-width:34ch}
+/* ===== HERO (förvandlingsvideon loopar som gif) ===== */
+.hero-standalone{position:relative;width:100%;height:100svh;display:flex;align-items:center;justify-content:center;overflow:hidden;z-index:10}
+.hero-vid-wrap{position:absolute;inset:0}
+.hero-vid-wrap video{width:100%;height:100%;object-fit:cover}
+.hero-vid-wrap::after{content:'';position:absolute;inset:0;background:
+  linear-gradient(180deg,rgba(11,11,13,.6) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
+.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw}
+.hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
+.hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
+.hero-heading .word{display:inline-block;opacity:0;transform:translateY(60px)}
+.hero-heading .accent{background:var(--grad);background-size:220% auto;-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;animation:shimmer 7s linear infinite}
+@keyframes shimmer{to{background-position:220% center}}
+.hero-tagline{font-size:clamp(.74rem,1.1vw,.95rem);font-weight:400;letter-spacing:.18em;color:var(--muted);text-transform:uppercase;opacity:0}
+.hero-scroll-indicator{position:absolute;bottom:2.6rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0;z-index:2}
+.hero-scroll-indicator span{font-size:.58rem;letter-spacing:.32em;color:var(--dim);text-transform:uppercase}
+.scroll-arrow{width:1px;height:42px;position:relative;overflow:hidden}
+.scroll-arrow::after{content:'';position:absolute;top:-100%;left:0;width:1px;height:100%;background:var(--amber);animation:scrollDown 2.1s var(--ease) infinite}
+@keyframes scrollDown{0%{top:-100%}50%{top:0}100%{top:100%}}
+
+/* ===== FAST VIDEOLAGER (steget in-loopen bakom scroll-sektionerna) ===== */
+.bgvid-wrap{position:fixed;top:0;left:0;width:100%;height:100%;z-index:1;clip-path:circle(0% at 50% 50%);will-change:clip-path}
+.bgvid-wrap video{width:100%;height:100%;object-fit:cover;filter:brightness(.62)}
+.bgvid-wrap::after{content:'';position:absolute;inset:0;background:
+  radial-gradient(120% 90% at 50% 50%,transparent 0%,rgba(11,11,13,.66) 100%),
+  linear-gradient(180deg,rgba(11,11,13,.45) 0%,transparent 30%,transparent 70%,rgba(11,11,13,.5) 100%)}
+
+/* ===== DARK OVERLAY ===== */
+#dark-overlay{position:fixed;inset:0;background:var(--bg);opacity:0;z-index:3;pointer-events:none;will-change:opacity}
+
+/* ===== MARQUEE ===== */
+.marquee-wrap{position:fixed;z-index:4;pointer-events:none;width:100%;opacity:0;will-change:opacity;top:14%}
+.marquee-text{white-space:nowrap;font-family:var(--disp);font-size:clamp(3.4rem,11vw,12vw);font-weight:900;text-transform:uppercase;color:transparent;-webkit-text-stroke:1px rgba(232,163,61,.45);letter-spacing:.03em;will-change:transform}
+
+/* ===== SCROLL CONTAINER ===== */
+#scroll-container{position:relative;width:100%;height:900vh;z-index:5}
+
+/* ===== SEKTIONER ===== */
+.scroll-section{position:absolute;width:100%;display:flex;align-items:center;opacity:0;visibility:hidden;will-change:transform,opacity}
+.scroll-section.active{opacity:1;visibility:visible}
+.align-left{padding-left:6vw;padding-right:50vw}
+.align-right{padding-left:50vw;padding-right:6vw}
+.align-left .section-inner,.align-right .section-inner{max-width:42vw}
+.section-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.4em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:1.2rem}
+.section-heading{font-family:var(--disp);font-size:clamp(1.9rem,4.6vw,4.4rem);font-weight:900;line-height:1.04;text-transform:uppercase;letter-spacing:-.01em;margin-bottom:1.2rem;text-shadow:0 4px 30px rgba(0,0,0,.5)}
+.section-body{font-size:clamp(.86rem,1vw,1rem);font-weight:400;line-height:1.8;color:var(--muted);max-width:480px}
+.section-note{font-size:clamp(.92rem,1.15vw,1.1rem);color:var(--amber-lt);margin-top:1.2rem;font-weight:500;font-style:italic}
+
+/* ===== FÖRE/EFTER ===== */
+.section-beforeafter{justify-content:center;padding:0 5vw}
+.ba-container{position:relative;width:min(920px,86vw);aspect-ratio:16/10;border-radius:8px;overflow:hidden;cursor:ew-resize;border:1px solid var(--line);box-shadow:0 40px 110px -30px rgba(0,0,0,.7)}
+.ba-side{position:absolute;inset:0}
+.ba-before{z-index:1}
+.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182550_1cb0eee4-3864-454a-abde-ddb5b00bd1f7.png') center/cover no-repeat}
+.ba-after{clip-path:inset(0 100% 0 0);z-index:2}
+.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182740_5c48f715-f0c5-4357-9d90-7e9f50c4a596.png') center/cover no-repeat}
+.ba-before-label,.ba-after-label{position:absolute;bottom:1.4rem;font-size:.56rem;letter-spacing:.28em;text-transform:uppercase;font-weight:700;z-index:5;background:rgba(11,11,13,.78);padding:.45rem .95rem;border-radius:999px;backdrop-filter:blur(4px)}
+.ba-before-label{left:1.4rem;color:var(--muted)}
+.ba-after-label{right:1.4rem;color:var(--amber-lt)}
+.ba-line{position:absolute;top:0;bottom:0;width:1px;background:var(--amber);z-index:10;left:0%;box-shadow:0 0 10px rgba(232,163,61,.6)}
+.ba-line::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:42px;height:42px;border:1px solid var(--amber);border-radius:50%;background:rgba(11,11,13,.82);backdrop-filter:blur(4px)}
+.ba-line::after{content:'⟷';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--amber);font-size:.72rem}
+.ba-heading{position:absolute;top:-5.2rem;left:0;right:0;text-align:center;z-index:5}
+.ba-heading .section-label{margin-bottom:.5rem}
+.ba-heading .section-heading{font-size:clamp(1.4rem,3vw,2.8rem);margin-bottom:0}
+
+/* ===== PROJEKT ===== */
+.section-projects{justify-content:center;padding:0 5vw}
+.projects-inner{width:min(1240px,92vw)}
+.projects-head{text-align:center;margin-bottom:2.2rem}
+.projects-head .section-heading{margin-bottom:.4rem}
+.projects-head p{color:var(--dim);font-size:.84rem}
 .work-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.1rem}
-.wcard{position:relative;border-radius:8px;overflow:hidden;background:var(--card);aspect-ratio:4/4.6;border:1px solid var(--line);will-change:transform,opacity}
+.wcard{position:relative;border-radius:8px;overflow:hidden;background:var(--card);aspect-ratio:4/4.4;border:1px solid var(--line)}
 .wcard img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform 1.1s var(--ease)}
 .wcard:hover img{transform:scale(1.06)}
-.wcard::after{content:'';position:absolute;inset:0;background:linear-gradient(180deg,transparent 38%,rgba(11,11,13,.92) 100%)}
+.wcard::after{content:'';position:absolute;inset:0;background:linear-gradient(180deg,transparent 38%,rgba(11,11,13,.94) 100%)}
 .wc-body{position:absolute;left:1.3rem;right:1.3rem;bottom:1.2rem;z-index:2}
-.wc-tag{font-size:.58rem;font-weight:700;letter-spacing:.22em;text-transform:uppercase;color:var(--amber-lt)}
-.wc-body h3{font-family:var(--disp);font-weight:800;font-size:1.3rem;margin:.3rem 0 .25rem}
-.wc-body p{font-size:.78rem;color:var(--muted)}
+.wc-tag{font-size:.56rem;font-weight:700;letter-spacing:.22em;text-transform:uppercase;color:var(--amber-lt)}
+.wc-body h3{font-family:var(--disp);font-weight:800;font-size:1.25rem;margin:.3rem 0 .2rem}
+.wc-body p{font-size:.76rem;color:var(--muted)}
 
-/* ── CINE (videoloop med text, gif-känsla) ── */
-.cine{position:relative;height:100svh;overflow:hidden;background:var(--bg)}
-.cine video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover}
-.cine::after{content:'';position:absolute;inset:0;pointer-events:none;background:
-  linear-gradient(180deg,rgba(11,11,13,.5) 0%,transparent 25%,transparent 70%,rgba(11,11,13,.6) 100%)}
-.cine-caption{position:absolute;inset:0;z-index:3;display:grid;place-items:center;text-align:center;padding:0 5vw}
-.cine-caption h2{font-family:var(--disp);font-weight:900;font-size:clamp(2.2rem,7.8vw,6.8rem);line-height:1;text-transform:uppercase;letter-spacing:-.01em;
-  text-shadow:0 6px 40px rgba(0,0,0,.55)}
-.cine-caption .sm{display:block;font-family:var(--sans);font-weight:500;font-size:clamp(.68rem,1vw,.85rem);letter-spacing:.3em;color:var(--amber-lt);margin-bottom:1rem;text-shadow:none}
+/* ===== TJÄNSTER ===== */
+.services-list{display:flex;flex-direction:column;gap:1.6rem}
+.service-item{display:flex;align-items:baseline;gap:1rem;padding-bottom:1.1rem;border-bottom:1px solid rgba(232,163,61,.16)}
+.service-name{font-family:var(--disp);font-size:clamp(1.05rem,1.7vw,1.5rem);font-weight:800;flex:1}
+.service-tag{font-size:.7rem;letter-spacing:.16em;color:var(--amber-lt);font-weight:600;text-transform:uppercase}
+.service-time{font-size:.68rem;color:var(--dim)}
 
-/* ── CTA ── */
-.cta{padding:clamp(6rem,13vw,10rem) clamp(1.2rem,4vw,3rem);text-align:center;position:relative;overflow:hidden}
-.cta::before{content:'';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:min(80vw,860px);aspect-ratio:1;
-  background:radial-gradient(circle,rgba(232,163,61,.13),transparent 62%);pointer-events:none}
-.cta h2{font-family:var(--disp);font-weight:900;font-size:clamp(2.2rem,6.5vw,5.2rem);text-transform:uppercase;line-height:1;position:relative}
-.cta p{color:var(--muted);margin:1.2rem auto 2.2rem;max-width:46ch;position:relative}
-.btn-big{display:inline-flex;align-items:center;gap:.7rem;background:var(--grad);color:#16120A;font-weight:800;font-size:.82rem;
-  letter-spacing:.16em;text-transform:uppercase;padding:1.15rem 2.6rem;border-radius:4px;position:relative;
-  box-shadow:0 18px 50px -18px rgba(232,163,61,.6);transition:transform .2s,box-shadow .3s}
-.btn-big:hover{transform:translateY(-2px);box-shadow:0 24px 60px -18px rgba(232,163,61,.8)}
-.btn-big svg{width:15px;height:15px;stroke:currentColor;stroke-width:2.4;fill:none}
-.cta-sub{font-size:.62rem;letter-spacing:.24em;text-transform:uppercase;color:var(--dim);margin-top:1.1rem;position:relative}
+/* ===== STATS ===== */
+.section-stats{justify-content:center;text-align:center;padding:0 5vw}
+.stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(1.5rem,4vw,4rem);max-width:920px;width:100%}
+.stat{display:flex;flex-direction:column;align-items:center;gap:.3rem}
+.stat-number{font-family:var(--disp);font-size:clamp(2.3rem,5vw,4.8rem);font-weight:900;line-height:1}
+.stat-suffix{font-family:var(--disp);font-size:clamp(1.1rem,2vw,1.9rem);font-weight:800;color:var(--amber);margin-left:.08em;display:inline}
+.stat-label{font-size:.58rem;letter-spacing:.26em;text-transform:uppercase;color:var(--dim);margin-top:.35rem}
 
-/* ── FOOTER ── */
-footer{border-top:1px solid var(--line);padding:1.8rem clamp(1.2rem,4vw,3rem);display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap;font-size:.72rem;color:var(--dim)}
+/* ===== CTA ===== */
+.section-cta{justify-content:center;text-align:center;padding:0 5vw}
+.cta-inner{display:flex;flex-direction:column;align-items:center;gap:1.4rem}
+.cta-button{position:relative;overflow:hidden;display:inline-flex;align-items:center;gap:.8rem;font-size:.74rem;font-weight:800;letter-spacing:.2em;text-transform:uppercase;color:#16120A;background:var(--grad);padding:1.15rem 2.8rem;border-radius:4px;box-shadow:0 18px 50px -18px rgba(232,163,61,.6);transition:box-shadow .35s,transform .25s}
+.cta-button::before{content:'';position:absolute;inset:0;background:var(--amber-lt);transform:scaleX(0);transform-origin:0 50%;transition:transform .45s var(--ease);z-index:0}
+.cta-button:hover::before{transform:scaleX(1)}
+.cta-button:hover{box-shadow:0 24px 60px -18px rgba(232,163,61,.8);transform:translateY(-2px)}
+.cta-button span,.cta-button svg{position:relative;z-index:1}
+.cta-button svg{width:15px;height:15px;stroke:currentColor;stroke-width:2.4;fill:none;transition:transform .35s var(--ease)}
+.cta-button:hover svg{transform:translateX(4px)}
+.cta-sub{font-size:.6rem;letter-spacing:.24em;color:var(--dim);text-transform:uppercase}
+
+/* ===== FLYTANDE OFFERT-KNAPP ===== */
+#float-offert{position:fixed;bottom:max(2.4rem,env(safe-area-inset-bottom));right:2.4rem;z-index:90;background:var(--grad);color:#16120A;font-size:.64rem;font-weight:800;letter-spacing:.22em;text-transform:uppercase;padding:.85rem 1.7rem;border-radius:4px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 10px 30px -8px rgba(232,163,61,.5)}
+#float-offert.visible{opacity:1;transform:translateY(0);pointer-events:auto}
+#float-offert:hover{box-shadow:0 16px 40px -8px rgba(232,163,61,.7);transform:translateY(-2px) scale(1.03)}
+
+/* ===== FOOTER ===== */
+footer{position:relative;z-index:6;border-top:1px solid var(--line);padding:1.8rem clamp(1.2rem,4vw,3rem);display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap;font-size:.7rem;color:var(--dim);background:var(--bg)}
 footer a{color:var(--amber-lt)}
 
-/* ── MODAL (Bahko demo) ── */
-.modal-bg{position:fixed;inset:0;z-index:500;background:rgba(11,11,13,.7);backdrop-filter:blur(10px);display:grid;place-items:center;
-  padding:1.2rem;opacity:0;visibility:hidden;transition:.35s}
+/* ===== MODAL (Bahko demo) ===== */
+.modal-bg{position:fixed;inset:0;z-index:500;background:rgba(11,11,13,.72);backdrop-filter:blur(10px);display:grid;place-items:center;padding:1.2rem;opacity:0;visibility:hidden;transition:.35s}
 .modal-bg.open{opacity:1;visibility:visible}
-.modal{background:var(--bg2);border:1px solid rgba(232,163,61,.3);border-radius:12px;max-width:480px;width:100%;padding:2.6rem;position:relative;
-  box-shadow:0 40px 110px rgba(0,0,0,.6)}
+.modal{background:var(--bg2);border:1px solid rgba(232,163,61,.3);border-radius:12px;max-width:480px;width:100%;padding:2.6rem;position:relative;box-shadow:0 40px 110px rgba(0,0,0,.6)}
 .modal-x{position:absolute;top:1rem;right:1.2rem;font-size:1.3rem;color:var(--dim);padding:.4rem}
 .modal-x:hover{color:var(--text)}
-.m-badge{display:inline-block;font-size:.58rem;letter-spacing:.24em;text-transform:uppercase;color:var(--amber-lt);
-  background:rgba(232,163,61,.1);border:1px solid rgba(232,163,61,.25);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.3rem}
+.m-badge{display:inline-block;font-size:.58rem;letter-spacing:.24em;text-transform:uppercase;color:var(--amber-lt);background:rgba(232,163,61,.1);border:1px solid rgba(232,163,61,.25);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.3rem}
 .modal h3{font-family:var(--disp);font-weight:800;font-size:1.7rem;line-height:1.15;margin-bottom:.6rem}
 .modal p{font-size:.88rem;color:var(--muted);margin-bottom:1.6rem}
-.modal .btn-big{width:100%;justify-content:center;font-size:.74rem;padding:1rem 1.4rem}
+.modal .cta-button{width:100%;justify-content:center;font-size:.72rem;padding:1rem 1.4rem}
 .m-alt{display:block;text-align:center;font-size:.74rem;color:var(--dim);margin-top:1rem;transition:color .3s}
 .m-alt:hover{color:var(--amber-lt)}
 .m-foot{margin-top:1.6rem;padding-top:1.1rem;border-top:1px solid var(--line);text-align:center;font-size:.62rem;letter-spacing:.16em;color:var(--dim)}
 .m-foot a{color:var(--amber-lt);font-weight:600}
 
-/* ── MOBIL ── */
-@media(max-width:760px){
-  .work-grid{grid-template-columns:1fr}
-  .wcard{aspect-ratio:4/3.4}
-  .hero-meta{gap:1.4rem}
-  .scrollcue{display:none}
+/* ===== MOBIL ===== */
+@media(max-width:768px){
+  .header-nav{display:none}
+  .hamburger{display:flex}
+  .align-left,.align-right{padding-left:6vw;padding-right:6vw}
+  .align-left .section-inner,.align-right .section-inner{max-width:100%}
+  .scroll-section .section-inner{background:rgba(11,11,13,.74);backdrop-filter:blur(8px);padding:1.8rem;border-radius:8px;border:1px solid var(--line)}
+  #scroll-container{height:620vh}
+  .work-grid{grid-template-columns:1fr;gap:.9rem}
+  .wcard{aspect-ratio:4/2.8}
+  .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.8rem}
+  .ba-container{width:92vw;aspect-ratio:16/11}
+  .ba-heading{top:-4.4rem}
+  .marquee-text{font-size:clamp(2.4rem,12vw,8rem)}
+  .hero-heading{font-size:clamp(2.3rem,11vw,5rem)}
+  .cta-button{padding:.95rem 2rem;width:100%;justify-content:center}
+  #float-offert{bottom:max(1.4rem,env(safe-area-inset-bottom));right:1.4rem;font-size:.58rem;padding:.72rem 1.3rem}
   .modal{padding:1.8rem 1.4rem}
+  .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
 }
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
-  .hero h1 .row>span{transform:none!important}
+  #loader{display:none}
+  #scroll-container{height:auto}
+  .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+  .hero-label,.hero-tagline,.hero-scroll-indicator{opacity:1!important}
+  .hero-heading .word{opacity:1!important;transform:none!important}
+  .bgvid-wrap{display:none}
+  .marquee-wrap{display:none}
 }
 </style>
 </head>
 <body>
 
-<nav class="nav" id="nav">
-  <a class="logo" href="#">GRANIT<em>.</em></a>
-  <a class="nav-cta" href="#" onclick="openModal();return false">Begär offert</a>
+<!-- LOADER -->
+<div id="loader">
+  <div class="loader-brand">GRANIT<em>.</em></div>
+  <div id="loader-bar-wrap"><div id="loader-bar"></div></div>
+  <div id="loader-percent">0%</div>
+</div>
+
+<!-- MOBILNAV -->
+<nav class="mobile-nav" id="mobile-nav">
+  <a href="#" onclick="closeMobileNav()">Projekt</a>
+  <a href="#" onclick="closeMobileNav()">Tjänster</a>
+  <a href="#" onclick="closeMobileNav()">Om Oss</a>
+  <a href="#" onclick="openModal();closeMobileNav()">Begär Offert</a>
 </nav>
 
-<!-- HERO — förvandlingsvideon loopar som en gif: gammalt hus → drömhus -->
-<header class="hero">
-  <div class="hero-bg">
+<!-- HEADER -->
+<header class="site-header" id="site-header">
+  <a href="#" class="header-logo">GRANIT<em>.</em></a>
+  <nav class="header-nav">
+    <a href="#">Projekt</a>
+    <a href="#">Tjänster</a>
+    <a href="#">Om Oss</a>
+    <a href="#" class="nav-cta" onclick="openModal();return false">Begär Offert</a>
+  </nav>
+  <button class="hamburger" id="hamburger" onclick="toggleMobileNav()" aria-label="Meny">
+    <span></span><span></span><span></span>
+  </button>
+</header>
+
+<!-- HERO — förvandlingsvideon loopar som gif -->
+<section class="hero-standalone">
+  <div class="hero-vid-wrap">
     <video id="hero-vid" autoplay muted loop playsinline preload="auto"
       poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182550_1cb0eee4-3864-454a-abde-ddb5b00bd1f7.png"
       src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182857_9ce4a497-1a91-433a-b04a-392b167a726b.mp4"></video>
   </div>
-  <div class="hero-inner">
-    <div class="hero-kicker">Bygg &amp; Totalrenovering · Mälardalen</div>
-    <h1>
-      <span class="row"><span>Vi ser huset</span></span>
-      <span class="row"><span class="grad-text">ingen annan ser.</span></span>
+  <div class="hero-content">
+    <span class="hero-label">Bygg &amp; Totalrenovering · Mälardalen</span>
+    <h1 class="hero-heading">
+      <span class="word">Vi ser huset</span><br>
+      <span class="word accent">ingen annan ser.</span>
     </h1>
-    <p class="hero-sub">Andra ser ett rivningsobjekt. Vi ser ett drömhus som väntar. Fast pris på papper, hållen tidplan — och tio års garanti på förvandlingen.</p>
-    <div class="hero-meta">
-      <div class="hm"><b>240+</b><span>Projekt levererade</span></div>
-      <div class="hm"><b>10 år</b><span>Garanti på allt</span></div>
-      <div class="hm"><b>4.9 ★</b><span>Snittbetyg</span></div>
-    </div>
+    <p class="hero-tagline">Fast pris på papper · Hållen tidplan · 10 års garanti</p>
   </div>
-  <div class="scrollcue">Scrolla <i></i></div>
-</header>
-
-<!-- VISION -->
-<section class="vision" id="vision">
-  <h2 data-reveal>Varannan byggfirma bygger för besiktningen.<br><em>Vi bygger för generationen efter dig.</em></h2>
-  <p data-reveal>Inget försvinnande efter handpenningen. Inga "det blev lite dyrare". Du får en ansvarig projektledare, ett fast pris på papper och ett dagsfotat bygge du kan följa från soffan.</p>
-</section>
-
-<!-- PROJEKT -->
-<section class="work" id="projekt">
-  <div class="work-head">
-    <h2 data-reveal>Välj hantverk.<br><span class="grad-text">Inte chansning.</span></h2>
-    <p data-reveal>Tre av våra senaste leveranser — fast pris, färdiga i tid.</p>
-  </div>
-  <div class="work-grid">
-    <article class="wcard" data-card>
-      <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_094812_ad5bfa2e-fd73-4f3f-ab72-a64cb45ccbba.png" alt="Nybyggd villa med svart träfasad" loading="lazy">
-      <div class="wc-body">
-        <div class="wc-tag">Nybyggnation</div>
-        <h3>Villa Ekerö</h3>
-        <p>Lösvirkeshus 162 m² — från ritning till nyckel på 9 månader.</p>
-      </div>
-    </article>
-    <article class="wcard" data-card>
-      <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_094814_51875d18-ee08-4322-8dd1-d7e4040e14bf.png" alt="Takläggning i skiffer" loading="lazy">
-      <div class="wc-body">
-        <div class="wc-tag">Tak &amp; Plåt</div>
-        <h3>Takbyte Bromma</h3>
-        <p>Komplett takbyte med skiffer — klart på 12 arbetsdagar.</p>
-      </div>
-    </article>
-    <article class="wcard" data-card>
-      <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_094816_a60d73a8-5553-4747-aab1-ea4c35755772.png" alt="Totalrenoverat badrum i mörk sten" loading="lazy">
-      <div class="wc-body">
-        <div class="wc-tag">Totalrenovering</div>
-        <h3>Badrum Vasastan</h3>
-        <p>Helkaklat med natursten och mässing — våtrumscertifierat.</p>
-      </div>
-    </article>
+  <div class="hero-scroll-indicator">
+    <span>Se förvandlingen</span>
+    <div class="scroll-arrow"></div>
   </div>
 </section>
 
-<!-- STEGET IN — videoloop som en gif: genom dörren in i drömhuset -->
-<section class="cine" id="cine2">
-  <video id="vid2" autoplay muted loop playsinline preload="metadata"
+<!-- FAST VIDEOLAGER — steget in-loopen bakom sektionerna -->
+<div class="bgvid-wrap" id="bgvid-wrap">
+  <video id="bg-vid" autoplay muted loop playsinline preload="metadata"
     poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182740_5c48f715-f0c5-4357-9d90-7e9f50c4a596.png"
     src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182942_0a03fd06-ff6d-4bca-a454-1e2ff82f88f0.mp4"></video>
-  <div class="cine-caption">
-    <h2 data-reveal><span class="sm">GRANIT Bygg &amp; Entreprenad</span>Välkommen<br><span class="grad-text">hem.</span></h2>
-  </div>
-</section>
+</div>
+<div id="dark-overlay"></div>
 
-<!-- CTA -->
-<section class="cta">
-  <h2>Vad ser du i <span class="grad-text">ditt hus?</span></h2>
-  <p>Berätta om ditt projekt så återkommer vi med ett fast pris inom 48 timmar — kostnadsfritt och utan förpliktelser.</p>
-  <button class="btn-big" onclick="openModal()">
-    <span>Begär kostnadsfri offert</span>
-    <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-  </button>
-  <div class="cta-sub">Svar inom 48h · Fast pris · 10 års garanti</div>
-</section>
+<!-- MARQUEE -->
+<div class="marquee-wrap" data-scroll-speed="-22" data-enter="12" data-leave="86">
+  <div class="marquee-text">Fast pris — Färdigt i tid — 10 års garanti — Byggt att ärvas —&nbsp;</div>
+</div>
+
+<!-- SCROLL CONTAINER -->
+<div id="scroll-container">
+
+  <section class="scroll-section align-left" data-enter="10" data-leave="22" data-animation="slide-left">
+    <div class="section-inner">
+      <span class="section-label">001 / Filosofi</span>
+      <h2 class="section-heading">Vi river inte<br>drömmar.</h2>
+      <p class="section-body">Varannan byggfirma bygger för besiktningen. Vi bygger för generationen efter dig. Inget försvinnande efter handpenningen, inga "det blev lite dyrare" — en ansvarig projektledare och ett dagsfotat bygge du följer från soffan.</p>
+      <p class="section-note">"Andra ser ett rivningsobjekt. Vi ser ett drömhus som väntar."</p>
+    </div>
+  </section>
+
+  <section class="scroll-section section-beforeafter" data-enter="24" data-leave="38" data-animation="fade-up">
+    <div style="position:relative">
+      <div class="ba-heading">
+        <span class="section-label">002 / Resultat · Totalrenovering</span>
+        <h2 class="section-heading">Samma hus.<br><span class="grad-text">Nytt liv.</span></h2>
+      </div>
+      <div class="ba-container" id="ba-container">
+        <div class="ba-side ba-before">
+          <span class="ba-before-label">Före</span>
+        </div>
+        <div class="ba-side ba-after" id="ba-after">
+          <span class="ba-after-label">Efter</span>
+        </div>
+        <div class="ba-line" id="ba-line"></div>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section section-projects" data-enter="40" data-leave="54" data-animation="stagger-up">
+    <div class="projects-inner">
+      <div class="projects-head">
+        <span class="section-label">003 / Projekt</span>
+        <h2 class="section-heading">Välj hantverk.<br><span class="grad-text">Inte chansning.</span></h2>
+        <p>Tre av våra senaste leveranser — fast pris, färdiga i tid.</p>
+      </div>
+      <div class="work-grid">
+        <article class="wcard">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_094812_ad5bfa2e-fd73-4f3f-ab72-a64cb45ccbba.png" alt="Nybyggd villa med svart träfasad" loading="lazy">
+          <div class="wc-body">
+            <div class="wc-tag">Nybyggnation</div>
+            <h3>Villa Ekerö</h3>
+            <p>Lösvirkeshus 162 m² — från ritning till nyckel på 9 månader.</p>
+          </div>
+        </article>
+        <article class="wcard">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_094814_51875d18-ee08-4322-8dd1-d7e4040e14bf.png" alt="Takläggning i skiffer" loading="lazy">
+          <div class="wc-body">
+            <div class="wc-tag">Tak &amp; Plåt</div>
+            <h3>Takbyte Bromma</h3>
+            <p>Komplett takbyte med skiffer — klart på 12 arbetsdagar.</p>
+          </div>
+        </article>
+        <article class="wcard">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_094816_a60d73a8-5553-4747-aab1-ea4c35755772.png" alt="Totalrenoverat badrum i mörk sten" loading="lazy">
+          <div class="wc-body">
+            <div class="wc-tag">Totalrenovering</div>
+            <h3>Badrum Vasastan</h3>
+            <p>Helkaklat med natursten och mässing — våtrumscertifierat.</p>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section align-right" data-enter="56" data-leave="68" data-animation="slide-right">
+    <div class="section-inner">
+      <span class="section-label">004 / Tjänster</span>
+      <h2 class="section-heading">Rätt hantverkare.<br>Rätt resultat.</h2>
+      <div class="services-list">
+        <div class="service-item">
+          <span class="service-name">Totalrenovering</span>
+          <span class="service-tag">Fast pris</span>
+          <span class="service-time">Villa &amp; lägenhet</span>
+        </div>
+        <div class="service-item">
+          <span class="service-name">Tak &amp; Plåt</span>
+          <span class="service-tag">Fast pris</span>
+          <span class="service-time">Tegel · Plåt · Skiffer</span>
+        </div>
+        <div class="service-item">
+          <span class="service-name">Badrum &amp; Våtrum</span>
+          <span class="service-tag">Certifierat</span>
+          <span class="service-time">Säker Vatten</span>
+        </div>
+        <div class="service-item">
+          <span class="service-name">Tillbyggnad &amp; Altan</span>
+          <span class="service-tag">Bygglovshjälp</span>
+          <span class="service-time">Ritning till nyckel</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section section-stats" data-enter="70" data-leave="82" data-animation="stagger-up">
+    <div class="stats-grid">
+      <div class="stat">
+        <div><span class="stat-number" data-value="240" data-decimals="0">0</span><span class="stat-suffix">+</span></div>
+        <span class="stat-label">Projekt levererade</span>
+      </div>
+      <div class="stat">
+        <div><span class="stat-number" data-value="10" data-decimals="0">0</span><span class="stat-suffix"> år</span></div>
+        <span class="stat-label">Garanti på allt</span>
+      </div>
+      <div class="stat">
+        <div><span class="stat-number" data-value="4.9" data-decimals="1">0</span><span class="stat-suffix"> ★</span></div>
+        <span class="stat-label">Snittbetyg</span>
+      </div>
+      <div class="stat">
+        <div><span class="stat-number" data-value="98" data-decimals="0">0</span><span class="stat-suffix">%</span></div>
+        <span class="stat-label">Rekommenderar oss</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section section-cta" data-enter="86" data-leave="100" data-animation="scale-up" data-persist="true">
+    <div class="cta-inner">
+      <span class="section-label">Nästa steg</span>
+      <h2 class="section-heading" style="font-size:clamp(2.4rem,6.5vw,6rem)">Vad ser du i<br><span class="grad-text">ditt hus?</span></h2>
+      <button class="cta-button" onclick="openModal()">
+        <span>Begär kostnadsfri offert</span>
+        <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </button>
+      <span class="cta-sub">Svar inom 48h · Fast pris · 10 års garanti</span>
+    </div>
+  </section>
+
+</div>
+
+<!-- FLYTANDE OFFERT-KNAPP -->
+<button id="float-offert" onclick="openModal()">Begär offert</button>
 
 <footer>
   <span>GRANIT Bygg &amp; Entreprenad · Demo</span>
@@ -243,7 +437,7 @@ footer a{color:var(--amber-lt)}
     <div class="m-badge">Demo av Bahko Byrå</div>
     <h3>Vill du ha en sida som denna för ditt byggföretag?</h3>
     <p>Boka ett kostnadsfritt 15-minuterssamtal med Mathias. Vi visar exakt hur din firmas hemsida kan se ut — och hur den drar in offertförfrågningar.</p>
-    <button class="btn-big" data-cal-namespace="15min" data-cal-link="bahkobyra/15min" data-cal-origin="https://cal.eu">Boka 15 min gratis samtal →</button>
+    <button class="cta-button" data-cal-namespace="15min" data-cal-link="bahkobyra/15min" data-cal-origin="https://cal.eu"><span>Boka 15 min gratis samtal →</span></button>
     <a class="m-alt" href="mailto:mathias@bahkobyra.se?subject=Intresserad av demo-hemsida (bygg)&body=Hej Mathias, jag såg GRANIT-demon och vill veta mer.">Eller mejla → mathias@bahkobyra.se</a>
     <div class="m-foot"><a href="https://bahkobyra.se" target="_blank" rel="noopener">Bahko Byrå</a> · Synlighet som säljer.</div>
   </div>
@@ -257,64 +451,211 @@ footer a{color:var(--amber-lt)}
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  // Autoplay-säkring: vissa mobillägen (lågenergi) blockerar autoplay tills första gest
-  function kickVideos(){
-    document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});
-  }
+  // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
+  function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
   addEventListener('touchstart',kickVideos,{once:true,passive:true});
   addEventListener('pointerdown',kickVideos,{once:true,passive:true});
 
   if(reduce){
-    // Reduced motion: pausa looparna, postern/första framen står stilla
     document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
+    document.getElementById('loader').classList.add('hidden');
+    return;
   }
-
   if(typeof gsap==='undefined')return;
   gsap.registerPlugin(ScrollTrigger);
 
-  if(!reduce&&typeof Lenis!=='undefined'){
-    const lenis=new Lenis({duration:1.1,easing:t=>1-Math.pow(1-t,3),smoothWheel:true});
-    lenis.on('scroll',ScrollTrigger.update);
-    gsap.ticker.add(t=>lenis.raf(t*1000));
-    gsap.ticker.lagSmoothing(0);
+  // ===== LENIS =====
+  const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+  lenis.on('scroll',ScrollTrigger.update);
+  gsap.ticker.add(t=>lenis.raf(t*1000));
+  gsap.ticker.lagSmoothing(0);
+
+  // ===== LOADER =====
+  const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
+  let loadProg=0;
+  (function simulateLoad(){
+    loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
+    loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
+    if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
+    else{setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+  })();
+
+  // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====
+  function animateHero(){
+    gsap.timeline()
+      .to('.hero-label',{opacity:1,duration:.8,ease:'power2.out'},0.2)
+      .to('.hero-heading .word',{opacity:1,y:0,stagger:.15,duration:1.05,ease:'power3.out'},0.4)
+      .to('.hero-tagline',{opacity:1,duration:.8,ease:'power2.out'},1.05)
+      .to('.hero-scroll-indicator',{opacity:1,duration:.8,ease:'power2.out'},1.35);
   }
 
-  // Nav
-  addEventListener('scroll',()=>document.getElementById('nav').classList.toggle('scrolled',scrollY>60),{passive:true});
+  // ===== SCROLL CONTAINER + HERO-UTFASNING + CIRKELAVTÄCKNING AV VIDEOLAGRET =====
+  const scrollContainer=document.getElementById('scroll-container');
+  const heroSection=document.querySelector('.hero-standalone');
+  const bgWrap=document.getElementById('bgvid-wrap');
 
-  if(reduce)return;
-
-  // Hero-entré
-  gsap.set('.hero h1 .row>span',{yPercent:115});
-  gsap.set('.hero-kicker,.hero-sub,.hero-meta,.scrollcue',{opacity:0,y:18});
-  gsap.timeline({delay:.15})
-    .to('.hero-kicker',{opacity:1,y:0,duration:.8,ease:'power3.out'})
-    .to('.hero h1 .row>span',{yPercent:0,duration:1.15,ease:'expo.out',stagger:.12},'-=.45')
-    .to('.hero-sub',{opacity:1,y:0,duration:.9,ease:'power3.out'},'-=.6')
-    .to('.hero-meta',{opacity:1,y:0,duration:.8,ease:'power3.out'},'-=.55')
-    .to('.scrollcue',{opacity:1,y:0,duration:.7},'-=.4');
-
-  // Hero-parallax på videon
-  gsap.to('#hero-vid',{yPercent:14,scale:1.06,ease:'none',
-    scrollTrigger:{trigger:'.hero',start:'top top',end:'bottom top',scrub:true}});
-
-  // Reveals
-  document.querySelectorAll('[data-reveal]').forEach(el=>{
-    gsap.fromTo(el,{y:46,opacity:0},{y:0,opacity:1,duration:1.05,ease:'expo.out',
-      scrollTrigger:{trigger:el,start:'top 86%'}});
+  ScrollTrigger.create({
+    trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+    onUpdate:self=>{
+      const p=self.progress;
+      heroSection.style.opacity=Math.max(0,1-p*14);
+      const wp=Math.min(1,Math.max(0,(p-0.005)/0.07));
+      bgWrap.style.clipPath=`circle(${wp*75}% at 50% 50%)`;
+    }
   });
 
-  // Projektkort
-  gsap.fromTo('[data-card]',{y:70,opacity:0,scale:.95},{y:0,opacity:1,scale:1,duration:1.1,ease:'expo.out',stagger:.12,
-    scrollTrigger:{trigger:'.work-grid',start:'top 84%'}});
+  // ===== SEKTIONER (absolut positionerade på progress-fönster, olika entréer) =====
+  const sections=document.querySelectorAll('.scroll-section');
+  function placeSections(){
+    sections.forEach(s=>{
+      const e=parseFloat(s.dataset.enter)/100,l=parseFloat(s.dataset.leave)/100,m=(e+l)/2;
+      s.style.top=(m*scrollContainer.offsetHeight)+'px'; s.style.transform='translateY(-50%)';
+    });
+  }
+  placeSections();
+
+  const sectionStates=new Map();
+  sections.forEach(section=>{
+    const type=section.dataset.animation,persist=section.dataset.persist==='true';
+    const enter=parseFloat(section.dataset.enter)/100,leave=parseFloat(section.dataset.leave)/100,fadeRange=0.03;
+    const children=section.querySelectorAll('.section-label,.section-heading,.section-body,.section-note,.cta-button,.cta-sub,.stat,.service-item,.wcard,.projects-head,.ba-container,.ba-heading');
+    const tl=gsap.timeline({paused:true});
+    switch(type){
+      case 'fade-up': tl.from(children,{y:50,opacity:0,stagger:.12,duration:.9,ease:'power3.out'}); break;
+      case 'slide-left': tl.from(children,{x:-80,opacity:0,stagger:.14,duration:.9,ease:'power3.out'}); break;
+      case 'slide-right': tl.from(children,{x:80,opacity:0,stagger:.14,duration:.9,ease:'power3.out'}); break;
+      case 'scale-up': tl.from(children,{scale:.85,opacity:0,stagger:.12,duration:1.0,ease:'power2.out'}); break;
+      case 'stagger-up': tl.from(children,{y:60,opacity:0,stagger:.13,duration:.85,ease:'power3.out'}); break;
+      case 'clip-reveal': tl.from(children,{clipPath:'inset(100% 0 0 0)',opacity:0,stagger:.15,duration:1.2,ease:'power4.inOut'}); break;
+    }
+    sectionStates.set(section,{tl,persist,enter,leave,fadeRange,active:false,persisted:false});
+  });
+
+  ScrollTrigger.create({
+    trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+    onUpdate:self=>{
+      const p=self.progress;
+      sectionStates.forEach((state,section)=>{
+        const{tl,persist,enter,leave,fadeRange}=state;
+        const shouldShow=p>=(enter-fadeRange)&&(persist?true:p<=(leave+fadeRange));
+        if(shouldShow&&!state.active){section.classList.add('active');section.style.visibility='visible';tl.play();state.active=true;}
+        else if(!shouldShow&&state.active&&!state.persisted){tl.reverse();state.active=false;}
+        if(persist&&state.active)state.persisted=true;
+        if(state.active||state.persisted){
+          let o=1;
+          if(p<enter)o=Math.max(0,(p-(enter-fadeRange))/fadeRange);
+          else if(!persist&&p>leave)o=Math.max(0,1-(p-leave)/fadeRange);
+          section.style.opacity=o;
+        } else {
+          section.style.opacity=0;
+        }
+      });
+    }
+  });
+
+  // ===== FÖRE/EFTER (scroll-avtäckning + drag) =====
+  const baAfter=document.getElementById('ba-after'),baLine=document.getElementById('ba-line'),baCont=document.getElementById('ba-container');
+  let baDragging=false,baScrollRevealed=false;
+  ScrollTrigger.create({
+    trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+    onUpdate:self=>{
+      const p=self.progress;
+      if(p>=0.26&&p<=0.36&&!baScrollRevealed){
+        const prog=(p-0.26)/(0.36-0.26);
+        baAfter.style.clipPath=`inset(0 ${(1-prog)*100}% 0 0)`;
+        baLine.style.left=(prog*100)+'%';
+      }
+      if(p>0.36)baScrollRevealed=true;
+    }
+  });
+  baCont.addEventListener('pointerdown',e=>{baDragging=true;baScrollRevealed=true;baCont.setPointerCapture(e.pointerId);});
+  baCont.addEventListener('pointermove',e=>{
+    if(!baDragging)return;
+    const r=baCont.getBoundingClientRect();
+    const pct=Math.max(0,Math.min(1,(e.clientX-r.left)/r.width));
+    baAfter.style.clipPath=`inset(0 ${(1-pct)*100}% 0 0)`;
+    baLine.style.left=(pct*100)+'%';
+  });
+  baCont.addEventListener('pointerup',()=>baDragging=false);
+
+  // ===== RÄKNARE =====
+  const animated=new Set();
+  document.querySelectorAll('.stat-number').forEach(el=>{
+    const target=parseFloat(el.dataset.value),decimals=parseInt(el.dataset.decimals||'0');
+    ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',
+      onUpdate:self=>{
+        const p=self.progress;
+        if(p>=0.70&&p<=0.82&&!animated.has(el)){
+          animated.add(el);
+          gsap.to({val:0},{val:target,duration:2,ease:'power1.out',onUpdate:function(){el.textContent=this.targets()[0].val.toFixed(decimals);}});
+        } else if(p<0.66&&animated.has(el)){animated.delete(el);el.textContent='0';}
+      }
+    });
+  });
+
+  // ===== DARK OVERLAY (två fönster: projekt + stats) =====
+  (function(){
+    const overlay=document.getElementById('dark-overlay');
+    const windows=[{e:0.39,l:0.55,max:0.5},{e:0.69,l:0.83,max:0.55}];
+    const fr=0.035;
+    ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+      onUpdate:self=>{
+        const p=self.progress;
+        let o=0;
+        windows.forEach(({e,l,max})=>{
+          if(p>=e-fr&&p<=e)o=Math.max(o,((p-(e-fr))/fr)*max);
+          else if(p>e&&p<l)o=Math.max(o,max);
+          else if(p>=l&&p<=l+fr)o=Math.max(o,max*(1-(p-l)/fr));
+        });
+        overlay.style.opacity=o;
+      }
+    });
+  })();
+
+  // ===== MARQUEE =====
+  document.querySelectorAll('.marquee-wrap').forEach(el=>{
+    const speed=parseFloat(el.dataset.scrollSpeed)||-25;
+    const enter=parseFloat(el.dataset.enter)/100,leave=parseFloat(el.dataset.leave)/100,fr=0.05;
+    gsap.to(el.querySelector('.marquee-text'),{xPercent:speed,ease:'none',scrollTrigger:{trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true}});
+    ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+      onUpdate:self=>{
+        const p=self.progress;
+        let o=0;
+        if(p>=enter&&p<=leave){const fi=Math.min(1,(p-enter)/fr),fo=Math.min(1,(leave-p)/fr);o=Math.min(fi,fo)*.9;}
+        el.style.opacity=o;
+      }
+    });
+  });
+
+  // ===== HEADER + FLYTKNAPP =====
+  addEventListener('scroll',()=>{
+    document.getElementById('site-header').classList.toggle('scrolled',scrollY>80);
+    document.getElementById('float-offert').classList.toggle('visible',scrollY>innerHeight*.6);
+  },{passive:true});
+
+  // ===== RESIZE =====
+  addEventListener('resize',()=>{placeSections();ScrollTrigger.refresh();});
 
   setTimeout(()=>ScrollTrigger.refresh(),400);
 })();
 
+// ===== MODAL =====
 function openModal(){document.getElementById('modal').classList.add('open');document.body.style.overflow='hidden';}
 function closeModal(){document.getElementById('modal').classList.remove('open');document.body.style.overflow='';}
 document.getElementById('modal').addEventListener('click',function(e){if(e.target===this)closeModal();});
 document.addEventListener('keydown',e=>{if(e.key==='Escape')closeModal();});
+
+// ===== MOBILNAV =====
+function toggleMobileNav(){
+  const nav=document.getElementById('mobile-nav'),btn=document.getElementById('hamburger');
+  nav.classList.toggle('open');btn.classList.toggle('open');
+  document.body.style.overflow=nav.classList.contains('open')?'hidden':'';
+}
+function closeMobileNav(){
+  document.getElementById('mobile-nav').classList.remove('open');
+  document.getElementById('hamburger').classList.remove('open');
+  document.body.style.overflow='';
+}
 </script>
 <!-- Cal.eu embed -->
 <script type="text/javascript">


### PR DESCRIPTION
## Vad

Bygg-demon ombyggd i **samma struktur som `/cloud/` (Élara)** — den koreografi vi alltid använder för kunddemos — men med Higgsfield-gif:arna i stället för ambient-canvas.

## Strukturen (1:1 med Élara)

- **Loader** med GRANIT-brand + progressbar
- **Ordvis hero-entré** med shimmer på accentordet — hero-bakgrunden är förvandlingsloopen (gif)
- **Fast videolager**: "Steget in"-loopen ligger fixed bakom alla sektioner och avtäcks med circle-wipe när heron scrollar bort (nedtonad + vinjett för läsbarhet)
- **900vh scroll-container** med absolut positionerade sektioner på progress-fönster och **varierade entréer**: slide-left → fade-up → stagger-up → slide-right → stagger-up → scale-up
- **Ny sektion: före/efter-slider** med keyframes A/B (gamla huset / drömhuset, samma vinkel) — scroll-avtäckning + draggbar linje
- **Stats med räknare** som tickar upp (240+, 10 år, 4.9★, 98 %)
- **Marquee** i outlined jättetext ("Fast pris — Färdigt i tid — 10 års garanti — Byggt att ärvas")
- Dark overlay-fönster över projekt- och stats-sektionerna, flytande offert-knapp, persist-CTA, hamburger/mobilnav, mobil-backdrop på textsektioner, reduced-motion gör sidan statisk
- Bahko-modal med Cal.eu oförändrad

Skillen uppdaterad: Élara-strukturen är nu dokumenterad som mall-standard för alla framtida kunddemos.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_