### PR TITLE
Bygg-demo: hero-krock, svart gap och marquee/före-efter fixade

### DIFF
--- a/bahkobyra/cloud/bygg/index.html
+++ b/bahkobyra/cloud/bygg/index.html
@@ -69,7 +69,7 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .hero-vid-wrap video{width:100%;height:100%;object-fit:cover}
 .hero-vid-wrap::after{content:'';position:absolute;inset:0;background:
   linear-gradient(180deg,rgba(11,11,13,.6) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
-.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw}
+.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(5rem,12vh,8rem)}
 .hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
 .hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
 .hero-heading .word{display:inline-block;opacity:0;transform:translateY(60px)}
@@ -92,12 +92,8 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 /* ===== DARK OVERLAY ===== */
 #dark-overlay{position:fixed;inset:0;background:var(--bg);opacity:0;z-index:3;pointer-events:none;will-change:opacity}
 
-/* ===== MARQUEE ===== */
-.marquee-wrap{position:fixed;z-index:4;pointer-events:none;width:100%;opacity:0;will-change:opacity;top:14%}
-.marquee-text{white-space:nowrap;font-family:var(--disp);font-size:clamp(3.4rem,11vw,12vw);font-weight:900;text-transform:uppercase;color:transparent;-webkit-text-stroke:1px rgba(232,163,61,.45);letter-spacing:.03em;will-change:transform}
-
 /* ===== SCROLL CONTAINER ===== */
-#scroll-container{position:relative;width:100%;height:900vh;z-index:5}
+#scroll-container{position:relative;width:100%;height:700vh;z-index:5}
 
 /* ===== SEKTIONER ===== */
 .scroll-section{position:absolute;width:100%;display:flex;align-items:center;opacity:0;visibility:hidden;will-change:transform,opacity}
@@ -109,24 +105,6 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .section-heading{font-family:var(--disp);font-size:clamp(1.9rem,4.6vw,4.4rem);font-weight:900;line-height:1.04;text-transform:uppercase;letter-spacing:-.01em;margin-bottom:1.2rem;text-shadow:0 4px 30px rgba(0,0,0,.5)}
 .section-body{font-size:clamp(.86rem,1vw,1rem);font-weight:400;line-height:1.8;color:var(--muted);max-width:480px}
 .section-note{font-size:clamp(.92rem,1.15vw,1.1rem);color:var(--amber-lt);margin-top:1.2rem;font-weight:500;font-style:italic}
-
-/* ===== FÖRE/EFTER ===== */
-.section-beforeafter{justify-content:center;padding:0 5vw}
-.ba-container{position:relative;width:min(920px,86vw);aspect-ratio:16/10;border-radius:8px;overflow:hidden;cursor:ew-resize;border:1px solid var(--line);box-shadow:0 40px 110px -30px rgba(0,0,0,.7)}
-.ba-side{position:absolute;inset:0}
-.ba-before{z-index:1}
-.ba-before::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182550_1cb0eee4-3864-454a-abde-ddb5b00bd1f7.png') center/cover no-repeat}
-.ba-after{clip-path:inset(0 100% 0 0);z-index:2}
-.ba-after::before{content:'';position:absolute;inset:0;background:url('https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182740_5c48f715-f0c5-4357-9d90-7e9f50c4a596.png') center/cover no-repeat}
-.ba-before-label,.ba-after-label{position:absolute;bottom:1.4rem;font-size:.56rem;letter-spacing:.28em;text-transform:uppercase;font-weight:700;z-index:5;background:rgba(11,11,13,.78);padding:.45rem .95rem;border-radius:999px;backdrop-filter:blur(4px)}
-.ba-before-label{left:1.4rem;color:var(--muted)}
-.ba-after-label{right:1.4rem;color:var(--amber-lt)}
-.ba-line{position:absolute;top:0;bottom:0;width:1px;background:var(--amber);z-index:10;left:0%;box-shadow:0 0 10px rgba(232,163,61,.6)}
-.ba-line::before{content:'';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:42px;height:42px;border:1px solid var(--amber);border-radius:50%;background:rgba(11,11,13,.82);backdrop-filter:blur(4px)}
-.ba-line::after{content:'⟷';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:var(--amber);font-size:.72rem}
-.ba-heading{position:absolute;top:-5.2rem;left:0;right:0;text-align:center;z-index:5}
-.ba-heading .section-label{margin-bottom:.5rem}
-.ba-heading .section-heading{font-size:clamp(1.4rem,3vw,2.8rem);margin-bottom:0}
 
 /* ===== PROJEKT ===== */
 .section-projects{justify-content:center;padding:0 5vw}
@@ -202,13 +180,10 @@ footer a{color:var(--amber-lt)}
   .align-left,.align-right{padding-left:6vw;padding-right:6vw}
   .align-left .section-inner,.align-right .section-inner{max-width:100%}
   .scroll-section .section-inner{background:rgba(11,11,13,.74);backdrop-filter:blur(8px);padding:1.8rem;border-radius:8px;border:1px solid var(--line)}
-  #scroll-container{height:620vh}
+  #scroll-container{height:500vh}
   .work-grid{grid-template-columns:1fr;gap:.9rem}
   .wcard{aspect-ratio:4/2.8}
   .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.8rem}
-  .ba-container{width:92vw;aspect-ratio:16/11}
-  .ba-heading{top:-4.4rem}
-  .marquee-text{font-size:clamp(2.4rem,12vw,8rem)}
   .hero-heading{font-size:clamp(2.3rem,11vw,5rem)}
   .cta-button{padding:.95rem 2rem;width:100%;justify-content:center}
   #float-offert{bottom:max(1.4rem,env(safe-area-inset-bottom));right:1.4rem;font-size:.58rem;padding:.72rem 1.3rem}
@@ -223,7 +198,6 @@ footer a{color:var(--amber-lt)}
   .hero-label,.hero-tagline,.hero-scroll-indicator{opacity:1!important}
   .hero-heading .word{opacity:1!important;transform:none!important}
   .bgvid-wrap{display:none}
-  .marquee-wrap{display:none}
 }
 </style>
 </head>
@@ -287,15 +261,10 @@ footer a{color:var(--amber-lt)}
 </div>
 <div id="dark-overlay"></div>
 
-<!-- MARQUEE -->
-<div class="marquee-wrap" data-scroll-speed="-22" data-enter="12" data-leave="86">
-  <div class="marquee-text">Fast pris — Färdigt i tid — 10 års garanti — Byggt att ärvas —&nbsp;</div>
-</div>
-
 <!-- SCROLL CONTAINER -->
 <div id="scroll-container">
 
-  <section class="scroll-section align-left" data-enter="10" data-leave="22" data-animation="slide-left">
+  <section class="scroll-section align-left" data-enter="8" data-leave="22" data-animation="slide-left">
     <div class="section-inner">
       <span class="section-label">001 / Filosofi</span>
       <h2 class="section-heading">Vi river inte<br>drömmar.</h2>
@@ -304,28 +273,10 @@ footer a{color:var(--amber-lt)}
     </div>
   </section>
 
-  <section class="scroll-section section-beforeafter" data-enter="24" data-leave="38" data-animation="fade-up">
-    <div style="position:relative">
-      <div class="ba-heading">
-        <span class="section-label">002 / Resultat · Totalrenovering</span>
-        <h2 class="section-heading">Samma hus.<br><span class="grad-text">Nytt liv.</span></h2>
-      </div>
-      <div class="ba-container" id="ba-container">
-        <div class="ba-side ba-before">
-          <span class="ba-before-label">Före</span>
-        </div>
-        <div class="ba-side ba-after" id="ba-after">
-          <span class="ba-after-label">Efter</span>
-        </div>
-        <div class="ba-line" id="ba-line"></div>
-      </div>
-    </div>
-  </section>
-
-  <section class="scroll-section section-projects" data-enter="40" data-leave="54" data-animation="stagger-up">
+  <section class="scroll-section section-projects" data-enter="26" data-leave="42" data-animation="stagger-up">
     <div class="projects-inner">
       <div class="projects-head">
-        <span class="section-label">003 / Projekt</span>
+        <span class="section-label">002 / Projekt</span>
         <h2 class="section-heading">Välj hantverk.<br><span class="grad-text">Inte chansning.</span></h2>
         <p>Tre av våra senaste leveranser — fast pris, färdiga i tid.</p>
       </div>
@@ -358,9 +309,9 @@ footer a{color:var(--amber-lt)}
     </div>
   </section>
 
-  <section class="scroll-section align-right" data-enter="56" data-leave="68" data-animation="slide-right">
+  <section class="scroll-section align-right" data-enter="46" data-leave="60" data-animation="slide-right">
     <div class="section-inner">
-      <span class="section-label">004 / Tjänster</span>
+      <span class="section-label">003 / Tjänster</span>
       <h2 class="section-heading">Rätt hantverkare.<br>Rätt resultat.</h2>
       <div class="services-list">
         <div class="service-item">
@@ -387,7 +338,7 @@ footer a{color:var(--amber-lt)}
     </div>
   </section>
 
-  <section class="scroll-section section-stats" data-enter="70" data-leave="82" data-animation="stagger-up">
+  <section class="scroll-section section-stats" data-enter="64" data-leave="78" data-animation="stagger-up">
     <div class="stats-grid">
       <div class="stat">
         <div><span class="stat-number" data-value="240" data-decimals="0">0</span><span class="stat-suffix">+</span></div>
@@ -408,7 +359,7 @@ footer a{color:var(--amber-lt)}
     </div>
   </section>
 
-  <section class="scroll-section section-cta" data-enter="86" data-leave="100" data-animation="scale-up" data-persist="true">
+  <section class="scroll-section section-cta" data-enter="84" data-leave="100" data-animation="scale-up" data-persist="true">
     <div class="cta-inner">
       <span class="section-label">Nästa steg</span>
       <h2 class="section-heading" style="font-size:clamp(2.4rem,6.5vw,6rem)">Vad ser du i<br><span class="grad-text">ditt hus?</span></h2>
@@ -489,18 +440,18 @@ footer a{color:var(--amber-lt)}
       .to('.hero-scroll-indicator',{opacity:1,duration:.8,ease:'power2.out'},1.35);
   }
 
-  // ===== SCROLL CONTAINER + HERO-UTFASNING + CIRKELAVTÄCKNING AV VIDEOLAGRET =====
+  // ===== CIRKELAVTÄCKNING: videolagret avtäcks MEDAN heron scrollar ut =====
+  // (knutet till heron, inte containern — videon är fullt synlig exakt när heron lämnat,
+  //  inget svart gap mellan hero och första sektionen)
   const scrollContainer=document.getElementById('scroll-container');
   const heroSection=document.querySelector('.hero-standalone');
   const bgWrap=document.getElementById('bgvid-wrap');
 
   ScrollTrigger.create({
-    trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+    trigger:heroSection,start:'top top',end:'bottom top',scrub:true,
     onUpdate:self=>{
       const p=self.progress;
-      heroSection.style.opacity=Math.max(0,1-p*14);
-      const wp=Math.min(1,Math.max(0,(p-0.005)/0.07));
-      bgWrap.style.clipPath=`circle(${wp*75}% at 50% 50%)`;
+      bgWrap.style.clipPath=`circle(${Math.min(1,p*1.35)*75}% at 50% 50%)`;
     }
   });
 
@@ -518,7 +469,7 @@ footer a{color:var(--amber-lt)}
   sections.forEach(section=>{
     const type=section.dataset.animation,persist=section.dataset.persist==='true';
     const enter=parseFloat(section.dataset.enter)/100,leave=parseFloat(section.dataset.leave)/100,fadeRange=0.03;
-    const children=section.querySelectorAll('.section-label,.section-heading,.section-body,.section-note,.cta-button,.cta-sub,.stat,.service-item,.wcard,.projects-head,.ba-container,.ba-heading');
+    const children=section.querySelectorAll('.section-label,.section-heading,.section-body,.section-note,.cta-button,.cta-sub,.stat,.service-item,.wcard,.projects-head');
     const tl=gsap.timeline({paused:true});
     switch(type){
       case 'fade-up': tl.from(children,{y:50,opacity:0,stagger:.12,duration:.9,ease:'power3.out'}); break;
@@ -553,31 +504,6 @@ footer a{color:var(--amber-lt)}
     }
   });
 
-  // ===== FÖRE/EFTER (scroll-avtäckning + drag) =====
-  const baAfter=document.getElementById('ba-after'),baLine=document.getElementById('ba-line'),baCont=document.getElementById('ba-container');
-  let baDragging=false,baScrollRevealed=false;
-  ScrollTrigger.create({
-    trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
-    onUpdate:self=>{
-      const p=self.progress;
-      if(p>=0.26&&p<=0.36&&!baScrollRevealed){
-        const prog=(p-0.26)/(0.36-0.26);
-        baAfter.style.clipPath=`inset(0 ${(1-prog)*100}% 0 0)`;
-        baLine.style.left=(prog*100)+'%';
-      }
-      if(p>0.36)baScrollRevealed=true;
-    }
-  });
-  baCont.addEventListener('pointerdown',e=>{baDragging=true;baScrollRevealed=true;baCont.setPointerCapture(e.pointerId);});
-  baCont.addEventListener('pointermove',e=>{
-    if(!baDragging)return;
-    const r=baCont.getBoundingClientRect();
-    const pct=Math.max(0,Math.min(1,(e.clientX-r.left)/r.width));
-    baAfter.style.clipPath=`inset(0 ${(1-pct)*100}% 0 0)`;
-    baLine.style.left=(pct*100)+'%';
-  });
-  baCont.addEventListener('pointerup',()=>baDragging=false);
-
   // ===== RÄKNARE =====
   const animated=new Set();
   document.querySelectorAll('.stat-number').forEach(el=>{
@@ -585,10 +511,10 @@ footer a{color:var(--amber-lt)}
     ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',
       onUpdate:self=>{
         const p=self.progress;
-        if(p>=0.70&&p<=0.82&&!animated.has(el)){
+        if(p>=0.64&&p<=0.78&&!animated.has(el)){
           animated.add(el);
           gsap.to({val:0},{val:target,duration:2,ease:'power1.out',onUpdate:function(){el.textContent=this.targets()[0].val.toFixed(decimals);}});
-        } else if(p<0.66&&animated.has(el)){animated.delete(el);el.textContent='0';}
+        } else if(p<0.60&&animated.has(el)){animated.delete(el);el.textContent='0';}
       }
     });
   });
@@ -596,7 +522,7 @@ footer a{color:var(--amber-lt)}
   // ===== DARK OVERLAY (två fönster: projekt + stats) =====
   (function(){
     const overlay=document.getElementById('dark-overlay');
-    const windows=[{e:0.39,l:0.55,max:0.5},{e:0.69,l:0.83,max:0.55}];
+    const windows=[{e:0.25,l:0.43,max:0.5},{e:0.63,l:0.79,max:0.55}];
     const fr=0.035;
     ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
       onUpdate:self=>{
@@ -611,21 +537,6 @@ footer a{color:var(--amber-lt)}
       }
     });
   })();
-
-  // ===== MARQUEE =====
-  document.querySelectorAll('.marquee-wrap').forEach(el=>{
-    const speed=parseFloat(el.dataset.scrollSpeed)||-25;
-    const enter=parseFloat(el.dataset.enter)/100,leave=parseFloat(el.dataset.leave)/100,fr=0.05;
-    gsap.to(el.querySelector('.marquee-text'),{xPercent:speed,ease:'none',scrollTrigger:{trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true}});
-    ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
-      onUpdate:self=>{
-        const p=self.progress;
-        let o=0;
-        if(p>=enter&&p<=leave){const fi=Math.min(1,(p-enter)/fr),fo=Math.min(1,(leave-p)/fr);o=Math.min(fi,fo)*.9;}
-        el.style.opacity=o;
-      }
-    });
-  });
 
   // ===== HEADER + FLYTKNAPP =====
   addEventListener('scroll',()=>{


### PR DESCRIPTION
## Vad

Tre fixar från din granskning av bygg-demon:

1. **Hero-krocken fixad** — innehållet har nu padding i botten så "Se förvandlingen"-indikatorn aldrig ligger över taglinen "Fast pris på papper · Hållen tidplan · 10 års garanti".
2. **Svarta gappet borta** — cirkel-avtäckningen av bakgrundsvideon är nu knuten till hero-utscrollningen i stället för scroll-containerns progress: videon är fullt avtäckt exakt i samma ögonblick som heron lämnat skärmen.
3. **Marquee-jättetexten ("FAST PRIS —") och före/efter-slidern borttagna.** Sektionerna omnumrerade (Filosofi → Projekt → Tjänster → Stats → CTA), progress-fönstren ombalanserade och scroll-containern kortad till 700vh (500vh mobil) så flödet inte känns utdraget.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_