### PR TITLE
Skill + minne: godkända demo-flödet sparat för framtida kunder

### DIFF
--- a/.claude/skills/scroll-cinematic/SKILL.md
+++ b/.claude/skills/scroll-cinematic/SKILL.md
@@ -1,42 +1,41 @@
 ---
 name: scroll-cinematic
-description: Use when someone asks to build a bygg-demo, scroll-cinematic demosajt, 3D scroll website för byggföretag, hus-förvandlings-demo, or "demo enligt GRANIT-mallen". Builds a cinematic scroll-driven demo site where an old broken house transforms into a dream home as you scroll, ending by walking in through the front door.
+description: Use when someone asks to build a bygg-demo, scroll-cinematic demosajt, 3D scroll website för byggföretag, hus-förvandlings-demo, or "demo enligt GRANIT-mallen". Builds a cinematic demo site where Higgsfield-generated loops of the same house (old → dream home → walking in the door) drive an Élara-style scroll choreography.
 argument-hint: [företagsnamn + nisch/ort, t.ex. "Tryggbyggservice badrum Stockholm"]
 disable-model-invocation: true
 ---
 
-# Scroll-Cinematic Bygg-Demo
+# Scroll-Cinematic Bygg-Demo (GRANIT-mallen)
 
-Bygger en demosajt för byggföretag enligt **GRANIT-mallen** med en filmisk scroll-resa:
-samma hus genom hela berättelsen — **gammalt & trasigt → förvandling → drömhus → kameran kliver IN genom dörren**.
-Higgsfield MCP genererar klippen (1080p), scrollen skrubbar videon.
+Bygger en kunddemo för byggföretag: **Élara-koreografin** (`bahkobyra/cloud/index.html`) — som ALLTID
+är strukturen för våra kunddemos — med **Higgsfield-genererade videoloopar (gif-känsla)** av samma hus:
+gammalt & trasigt → förvandlas till drömhus (hero-loopen) → kameran kliver in genom dörren (bakgrundsloopen).
+
+**Facit / godkänd slutversion: `bahkobyra/cloud/bygg/index.html`** — kopiera den till
+`bahkobyra/cloud/[kund]/index.html` och byt varumärke (namn, palett om kunden har egen, copy, klipp).
 
 **OBS: Kostar Higgsfield-credits (~150/demo). Kör aldrig utan explicit beställning.**
 
-## Berättelsen (fast koncept — ändra inte strukturen)
-
-**Strukturen = Élara-koreografin** (`bahkobyra/cloud/index.html`) — det är ALLTID den vi använder för
-kunddemos — med Higgsfield-gif:arna i stället för ambient-canvas. Facit för bygg:
-`bahkobyra/cloud/bygg/index.html`.
+## Strukturen (fast — ändra inte)
 
 | Del | Innehåll |
 |-----|----------|
-| Loader | Varumärke + progressbar (simulerad, snabb) |
-| Header | Fixed med nav-länkar + CTA-knapp; hamburger + helskärms-mobilnav under 768px |
-| Hero (100svh) | **Förvandlingsvideon som autoplay-loop (gif)** bakom ordvis staggad rubrik (`.word`, shimmer-accent), tagline, scroll-indikator. Heron tonar ut när scrollen börjar |
-| Fast videolager | **"Steget in"-loopen fixed bakom alla sektioner**, avtäcks med circle-wipe (`clip-path:circle`) när heron lämnar — nedtonad (brightness ~.62 + vinjett) för läsbarhet |
-| Scroll-container (900vh / 620vh mobil) | Absolut positionerade sektioner på progress-fönster (`data-enter`/`data-leave`), VARIERADE entréer — aldrig samma två gånger i rad: slide-left → fade-up → stagger-up → slide-right → stagger-up → scale-up |
-| Sektionerna | 001 Filosofi (sidoställd) · 002 **Före/efter-slider med keyframes A/B** (scroll-avtäckning + drag) · 003 Projektgrid (3 kort) · 004 Tjänstelista · 005 Stats med räknare som tickar upp · CTA med `data-persist="true"` |
-| Övrigt | Marquee i jättetext (outlined, xPercent på scroll) · dark overlay-fönster över projekt+stats · flytande offert-knapp efter 60 % viewport · Bahko-modal (Cal.eu) |
+| Loader | Varumärke + amber progressbar (simulerad, snabb ~1,5s) |
+| Header | Fixed: logo + nav-länkar + CTA-knapp · hamburger + helskärms-mobilnav < 768px |
+| Hero (100svh) | **Förvandlingsloopen (klipp 1) autoplay bakom** ordvis staggad rubrik (`.word`, shimmer-accent), tagline, scroll-indikator. `hero-content` har `padding-bottom:clamp(5rem,12vh,8rem)` så indikatorn ALDRIG krockar med taglinen |
+| Fast videolager | **"Steget in"-loopen (klipp 2) fixed bakom alla sektioner**, nedtonad (`brightness(.62)` + vinjett). **Circle-wipe:n är knuten till HERO-utscrollningen** (`trigger:hero, start:'top top', end:'bottom top'`, radie `min(1,p*1.35)*75%`) — fullt avtäckt exakt när heron lämnat = inget svart gap |
+| Scroll-container | **700vh desktop / 500vh mobil.** Absolut positionerade sektioner på progress-fönster, VARIERADE entréer — aldrig samma två gånger i rad |
+| Sektionsfönster | 001 Filosofi `8–22` slide-left · 002 Projektgrid (3 kort) `26–42` stagger-up · 003 Tjänstelista `46–60` slide-right · 004 Stats + räknare `64–78` stagger-up · CTA `84–100` scale-up + `data-persist="true"` |
+| Övrigt | Dark overlay-fönster `0.25–0.43` (max .5) och `0.63–0.79` (max .55) · räknare triggas `0.64–0.78`, nollas < `0.60` · flytande offert-knapp efter 60 % viewport · footer · Bahko-modal (Cal.eu `bahkobyra/15min`) · `noindex, nofollow` |
+
+**Medvetet BORTTAGET (beslut 2026-06-11 — lägg inte tillbaka):** marquee-jättetext och
+före/efter-slider — de krockade visuellt med videolagret. Säljlöftena bor i hero-tagline + cta-sub.
 
 **Videopresentation: autoplay-loopar (gif-känsla), INTE scroll-scrub.** `<video autoplay muted loop
-playsinline preload="auto" poster="<keyframe>">`. Gest-säkring (`touchstart/pointerdown` → `play()` på
-pausade videos) för lågenergiläge, och `prefers-reduced-motion`: pausa videos, döda loadern, gör
-sektionerna statiska (CSS: `#scroll-container{height:auto}`, `.scroll-section{position:static;opacity:1}`).
-
-**Mall/facit:** `bahkobyra/cloud/bygg/index.html` — kopiera den till `bahkobyra/cloud/[kund]/index.html`
-och byt varumärke (namn, färger om kunden har egna, copy, klipp). Behåll alltid: nav, vision,
-work-grid, CTA, footer, Bahko-modalen (Cal.eu `bahkobyra/15min`), `noindex`, reduced-motion-fallbacks.
+playsinline preload="auto" poster="<keyframe>">`. Gest-säkring: vid första `touchstart/pointerdown`
+→ `play()` på pausade videos (mobilens lågenergiläge kan blockera autoplay). `prefers-reduced-motion`:
+pausa videos, dölj loader/bgvid, gör sektionerna statiska (`#scroll-container{height:auto}`,
+`.scroll-section{position:static;opacity:1}`).
 
 ## Steg
 
@@ -48,7 +47,7 @@ generate_video med get_cost:true → verifiera klippkostnad (8s 1080p Seedance �
 ```
 
 Budget per demo: 3 bilder (nano_banana_pro, ~2 credits/st) + 2 videoklipp à 8s 1080p (~72/st) ≈ **150 credits**.
-Generera ALDRIG ett tredje "etablerings-klipp" — scrollens start håller ändå klipp 1:s första frame.
+Generera ALDRIG ett tredje "etablerings-klipp" — hero-loopen börjar ändå på gamla huset.
 
 ### 2. Generera keyframes (nano_banana_pro, 16:9)
 
@@ -66,12 +65,12 @@ Konsistensen bygger på referenskedjan — generera i exakt denna ordning:
 ### 3. Generera klippen (seedance_2_0 — stödjer start_image + end_image i 1080p)
 
 ```
-Klipp 1 "Förvandlingen": duration 8, aspect_ratio 16:9, resolution 1080p
+Klipp 1 "Förvandlingen" (hero-loopen): duration 8, aspect_ratio 16:9, resolution 1080p
   medias: [{value:A, role:'start_image'}, {value:B, role:'end_image'}]
   Prompt: "Cinematic time-lapse of a complete house renovation, locked-off camera, no camera movement…
   The first frame matches the start image exactly and the final frame matches the end image exactly."
 
-Klipp 2 "Steget in": samma params
+Klipp 2 "Steget in" (bakgrundsloopen): samma params
   medias: [{value:B, role:'start_image'}, {value:C, role:'end_image'}]
   Prompt: "Single continuous cinematic steadicam shot, smooth slow dolly forward… the door opens smoothly
   inward, and the camera continues through the doorway into the living room… no cuts."
@@ -79,45 +78,49 @@ Klipp 2 "Steget in": samma params
 
 - Får du en `preset_recommendation`-notis: kör om bokstavligt med `declined_preset_id` — vi vill ha exakt våra keyframes.
 - Polla med `job_display` tills `status: completed`; ta `results.rawUrl` (cloudfront-MP4).
+- Hotlinka rawUrl:erna i `<video src>` + keyframe-PNG:erna som `poster` (omedelbar första målning).
 
-### 4. Videopresentation — autoplay-loop (standard)
+### 4. Bygg sidan
 
-Hotlinka MP4-url:erna (`results.rawUrl`) i `<video autoplay muted loop playsinline preload="auto"
-poster="<keyframe>">`. Hero = klipp 1 bakom hero-copy (med GSAP-parallax på videoelementet),
-"Steget in" = klipp 2 i en 100svh-sektion med overlay-rubrik. Mallen ligger i
-`bahkobyra/cloud/bygg/index.html`. Gest-säkring: vid första `touchstart/pointerdown`, `play()` på
-alla pausade videos (lågenergiläge på mobil blockerar ibland autoplay). `prefers-reduced-motion`:
-pausa looparna (postern står stilla).
+Kopiera `bahkobyra/cloud/bygg/index.html` → `bahkobyra/cloud/[kund]/index.html` och byt:
+1. Varumärke: titel, logo, loader-brand, footer, palett-variabler om kunden har egen profil.
+2. Video-url:er + posters (klipp 1 i heron, klipp 2 i `.bgvid-wrap`).
+3. Copy per sektion (se copy-regler). Projektkortens bilder: generera 3 st i kundens nisch
+   (nano_banana_pro, ~2 credits/st) eller använd kundens egna jobbfoton om de finns.
+4. Stats: anpassa till kundens verkliga siffror om kända — hitta aldrig på verifierbara påståenden
+   åt en RIKTIG kund; demosiffror är OK för fiktiva varumärken som GRANIT.
 
-**Alternativ (endast om kunden uttryckligen ber om scroll-scrub):** `video.currentTime`-scrub kräver
-tre delar för att inte se fryst ut på mobil (lärdom 2026-06-11): (1) gest-upplåsning `play().then(pause)`
-vid första gest, (2) seek-kö — aldrig ny `currentTime` innan `'seeked'` har kommit, pumpa mot senaste
-målet, (3) buffert-uppvärmning via ScrollTrigger `start:'top 150%'`. Lokalt med ffmpeg: extrahera frames
-och kör canvas-scrub enligt video-to-website-skillen (mjukast). Historik: scrub-varianten finns i git
-(`git log bahkobyra/cloud/bygg/index.html`, commit "Videoscrub som faktiskt rör sig…").
+**Scroll-scrub (ENDAST om kunden uttryckligen ber om det):** `video.currentTime`-scrub kräver
+(1) gest-upplåsning `play().then(pause)` vid första gest, (2) seek-kö — aldrig ny `currentTime` innan
+`'seeked'`, pumpa mot senaste målet, (3) buffert-uppvärmning `start:'top 150%'`. Lokalt med ffmpeg:
+canvas-frames enligt video-to-website-skillen. Historik i git: commit "Videoscrub som faktiskt rör sig…".
 
 ### 5. Copy-regler
 
-- Akt 1-raderna berättar förvandlingen (3 st): "Vi river inte drömmar." → "Vi bygger fram dem." → "Från utdömt till drömhus."
-- Akt 2 (2 st): "Öppna dörren." → "Välkommen hem."
-- Säljlöftena (fast pris / i tid / garanti) bor i hero-meta + cta-sub — INTE i cine-raderna.
-- Allt på svenska, inga klyschor, GRANIT-tonen: kort, tungt, självsäkert.
+- Hero-rubrik: 2 rader, ordvis animerad, accentordet i grad-text ("Vi ser huset / ingen annan ser.").
+- Tagline = säljlöftena: "Fast pris på papper · Hållen tidplan · 10 års garanti".
+- Sektionsrubriker: korta, tunga, 2 rader, gärna grad-text på rad 2 ("Välj hantverk. / Inte chansning.").
+- CTA: fråga som öppnar ("Vad ser du i ditt hus?") + "Begär kostnadsfri offert" + cta-sub med löftena.
+- Allt på svenska, inga klyschor, GRANIT-tonen: kort, tungt, självsäkert. Aldrig "Växa på Google"-copy.
 
 ### 6. QA före leverans
 
-1. `node --check` på inline-scriptet (extrahera `<script>`-blocket).
-2. Verifiera att `__VIDEO1_URL__`/`__VIDEO2_URL__`-platshållare är ersatta med riktiga rawUrl:er.
-3. Posters = keyframe A (cine1) resp. B (cine2) så första målningen är omedelbar.
-4. `prefers-reduced-motion`: videorna ska falla tillbaka till autoplay-loop, cine-rader synliga utan scrub.
-5. Mobil: 100svh, `playsinline`, scrollcue dold under 760px.
-6. Committa, pusha, PR → main (Vercel deployar `bahkobyra/`).
+1. `node --check` på inline-scriptet (extrahera `<script>`-blocket med regex, kör mot temp-fil).
+2. Inga `__PLACEHOLDER__` kvar; båda `.mp4`-url:erna + posters satta.
+3. Sektionsfönster överlappar inte; dark overlay-/räknarfönster matchar sektionernas.
+4. Hero: indikatorn under taglinen (padding-bottom finns), `autoplay muted loop playsinline` på båda videos.
+5. Mobil: hamburger funkar, textsektioner får frostad backdrop, 500vh-container.
+6. `prefers-reduced-motion`: sidan statisk, videos pausade.
+7. Committa, pusha, PR → main (Vercel deployar `bahkobyra/`). Skicka demolänken: `bahkobyra.se/cloud/[kund]/`.
 
 ## Guardrails
 
 - **Credits:** preflight alltid `balance` + `get_cost`. Under 200 credits → fråga först. Max 1 retry per klipp.
 - **Hotlink-risken:** cloudfront-url:erna ägs av Higgsfield. Vid lokal körning: ladda ner och committa
-  MP4/frames i stället. Notera i PR:en vilken väg som användes.
+  MP4 i stället. Notera i PR:en vilken väg som användes. (Cloud-sandboxen kan INTE ladda ner från CDN:et
+  och saknar ffmpeg — där är hotlink enda vägen.)
 - **Konsistens före allt:** om keyframe B inte ser ut som SAMMA hus som A — generera om B med skarpare
   "IDENTICAL"-instruktion i stället för att acceptera ett annat hus. Det är hela konceptet.
-- Skriv aldrig "Växa på Google"-copy i demon (positioneringsregeln i CLAUDE.md).
-- Demon ska alltid ha `noindex, nofollow` och Bahko-modalen.
+- Demon ska alltid ha `noindex, nofollow` och Bahko-modalen (Cal.eu `bahkobyra/15min` + mailto till mathias@bahkobyra.se).
+- Jag kan inte spela upp klippen från sandboxen — be alltid användaren ögongranska förvandlingen
+  (samma hus?) och loopkänslan innan demon skickas till kund.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Skills live in `.claude/skills/[skill-name]/SKILL.md`. Descriptions are always l
 
 - **skill-builder** — Guides building/auditing/optimizing skills. Runs Discovery Interview before creating. See `.claude/skills/skill-builder/reference.md`.
 - **video-to-website** — Converts a video into a scroll-driven animated website (FFmpeg + GSAP + Lenis + canvas).
-- **scroll-cinematic** — Bygg-demosajter enligt GRANIT-mallen med Higgsfield-genererad husförvandling (gammalt hus → drömhus → kliv in) som loopande videohero + "Välkommen hem"-loop (gif-känsla, ej scrub). Kostar ~150 Higgsfield-credits/demo — körs aldrig utan beställning. Output: `bahkobyra/cloud/[kund]/index.html`.
+- **scroll-cinematic** — Kunddemos enligt GRANIT-mallen: **Élara-koreografin (`bahkobyra/cloud/index.html`) är ALLTID strukturen för kunddemos** (loader, ordvis hero, sektioner på progress-fönster med varierade entréer, räknare, flytknapp, persist-CTA, Bahko-modal). För bygg: Higgsfield-genererad husförvandling (gammalt hus → drömhus → kliv in) som autoplay-loopar/gif — ALDRIG scroll-scrub. Facit: `bahkobyra/cloud/bygg/index.html`. Kostar ~150 Higgsfield-credits/demo — körs aldrig utan beställning. Output: `bahkobyra/cloud/[kund]/index.html`.
 - **excalidraw-diagram** — Generates editable Excalidraw diagrams, saves `.excalidraw` files.
 - **rapport** — Genererar konkurrensanalys, klientrapporter och lead-profiler. Exporterar till Google Docs/Sheets. Kräver `credentials.json` för Google OAuth. Export-verktyg: `tools/export_to_google_docs.js`.
 - **instagram-engine** — Producerar content-batchar (reels/carouseller/DM-cadence) för bygg/hantverk-nischen (@bahkostudio). Speglas i dashboardens Instagram-motor. Se `.claude/skills/instagram-engine/templates.md`.


### PR DESCRIPTION
## Vad

Sparar hela det godkända demo-flödet till skill + minne så varje framtida kunddemo byggs exakt så här.

**`.claude/skills/scroll-cinematic/SKILL.md`** — omskriven till facit av slutversionen:
- Élara-koreografin som fast struktur, med exakta sektionsfönster (8–22/26–42/46–60/64–78/84–100), dark overlay- och räknarfönster, 700vh/500vh
- Gif-loopar som standard (aldrig scroll-scrub), gest-säkring, reduced-motion-beteende
- Circle-wipe knuten till hero-utscrollningen (inget svart gap) + hero-padding mot indikatorkrock
- Borttagna element dokumenterade som beslut (marquee, före/efter-slider) så de inte smyger tillbaka
- "Kopiera facit → byt varumärke"-flöde för nya kunder, copy-regler, QA-checklista, credit-guardrails (~150/demo, preflight obligatorisk)
- Regel: hitta aldrig på verifierbara siffror åt riktiga kunder + be alltid användaren ögongranska klippen

**`CLAUDE.md`** — Élara-koreografin fastslagen i minnet som standardstruktur för ALLA kunddemos.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_