### PR TITLE
JA-protokollet sparat + färdiga demo-leveransmeddelanden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Källdokument i `reference/`. **Allt operativt körs från dashboarden:** `bahko
 - **Outreach-copy:** kort, personlig, mänsklig, hjälpsam. En konkret observation om DERAS sajt + en tydlig CTA.
 - **Front-offer = bevisa "the wizard"**, inte tjäna pengar. Sen uppsell.
 - **Cadence:** välj EN väg/lead (skriven/samtal/IRL), dag 1/3/5/7 → svar=boka, tyst=nurture/stäng.
+- **JA-protokollet (när prospekt säger ja till demo):** gör ENDAST tre saker, i ordning, max 30–50 ord totalt, lugn/saklig ton: 1) instruktion — "Titta bara på [plats] och notera hur [friktion] visar sig." 2) kvalificering (binär, låg friktion) — "Bara så jag förstår — ser du samma sak på din sida idag?" 3) optionalitet — "Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig." ALDRIG pitch, hype, värme-fluff, "let me know" eller call-push. Demo-länken levereras alltid. Full version + färdiga mallar i dashboardens Spelbok/skript.
 - **Daglig blast:** volym slår allt. Flaskhals = bokade möten/vecka.
 - **Nischer:** kliniker (CRM) + bygg/tak/måleri/mark (Instagram).
 

--- a/bahkobyra/dashboard/index.html
+++ b/bahkobyra/dashboard/index.html
@@ -631,6 +631,48 @@ DAG 5: Hann du kika? Kostar inget — bara ett konkret exempel på en sajt som d
 DAG 7: Sista pingen 🙂 Om en ny sajt inte är prio nu säg bara till.</pre>
       </div>
 
+      <div class="script">
+        <div class="script-h"><span class="nm">JA-protokollet · demo-leverans (mall)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
+        <pre>NÄR PROSPEKT SÄGER JA — gör ENDAST tre saker, i ordning. Max 30–50 ord. Lugn, saklig ton.
+1) Instruktion: "Titta bara på [plats] och notera hur [friktion] visar sig."
+2) Kvalificering: "Bara så jag förstår — ser du samma sak på din sida idag?"
+3) Optionalitet: "Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig."
+ALDRIG: pitch, hype, värme-fluff, "let me know", call-push. Demo-länken levereras alltid.</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">JA-svar · Tryggbyggservice (demo klar)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
+        <pre>Här är demon: bahkobyra.se/cloud/tryggbyggservice/
+
+Titta bara på sektionen direkt under rubriken — och notera hur allt går att kontrollera: fast pris, ansvar, papper.
+
+Bara så jag förstår — om en kund googlar er idag, hittar de något sådant?
+
+Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig.</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">JA-svar · Alfred Allservice (när demon är klar)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
+        <pre>Här är demon: [DEMOLÄNK]
+
+Öppna den i mobilen — och testa sen länken i er egen Instagram-bio och notera vad som händer när man klickar.
+
+Bara så jag förstår — visste du att den inte leder någonstans idag?
+
+Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig.</pre>
+      </div>
+
+      <div class="script">
+        <div class="script-h"><span class="nm">JA-svar · Bromma Trädgårdsservice (när demon är klar)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
+        <pre>Här är demon: [DEMOLÄNK]
+
+Titta bara på första skärmen — juni-läge, gräs och häckar. Jämför sen med vad dina följare möter via bio-länken idag.
+
+Bara så jag förstår — ser du samma sak på din sida?
+
+Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig.</pre>
+      </div>
+
     </div>
   </section>
 
@@ -838,6 +880,17 @@ Kör skillen instagram-engine för en full veckobatch (3 reels + 2 carouseller +
         </tbody>
       </table>
       <p class="note">Svar → ENGAGED (svara samma dag, boka möte). Inget svar dag 7 → eskalera EN gång → annars NURTURE (+30 d) eller STÄNG. Aldrig needy.</p>
+    </div>
+
+    <div class="play-card" style="margin-bottom:1rem">
+      <h4><span class="ic">✅</span> JA-protokollet — när prospekt säger ja till demo</h4>
+      <ul>
+        <li><strong>Gör ENDAST tre saker, i exakt denna ordning.</strong> Inget mer. Inga extra frågor. Ingen push mot samtal. Max 30–50 ord totalt, lugn och saklig ton. Demo-länken levereras alltid.</li>
+        <li><strong>1) Instruktion</strong> (visuellt, konkret, EN sak — platsen där friktionen syns): <em>"Titta bara på [plats] och notera hur [friktion] visar sig."</em></li>
+        <li><strong>2) Kvalificering</strong> (binär, låg friktion — ska inte kännas som säljfråga): <em>"Bara så jag förstår — ser du samma sak på din sida idag?"</em></li>
+        <li><strong>3) Optionalitet</strong> (be aldrig om samtal — öppna bara dörren): <em>"Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig."</em></li>
+        <li><strong>Förbjudet:</strong> pitch · hype · värme-fluff · "let me know" · call-push. Färdiga mallar per lead finns under Outreach-skripten.</li>
+      </ul>
     </div>
 
     <div class="play-grid">


### PR DESCRIPTION
## Vad

Sparar **JA-protokollet** (vad som händer när ett prospekt säger ja till demo) i kunskapsbasen, nu när alla tre IG-leads tackat ja.

## Innehåll

**CLAUDE.md (Säljsystem):** 3-stegsprotokollet — 1) instruktion ("Titta bara på [plats] och notera hur [friktion] visar sig"), 2) binär kvalificering ("ser du samma sak på din sida idag?"), 3) optionalitet ("kan jag visa nästa steg — helt upp till dig"). Max 30–50 ord, lugn ton, aldrig pitch/hype/"let me know"/call-push. Demo-länken levereras alltid.

**Dashboard:**
- Spelboken: fullt protokollkort med format och förbudslista
- Outreach-skripten: kopierbar mall + **tre färdiga JA-svar** — Tryggbyggservice (med demolänken inlagd, redo att skicka), Alfred Allservice och Bromma Trädgårdsservice (länk-platshållare tills deras demos är byggda)

Varje meddelande är skrivet mot leadets verifierade friktion ur researchen: Tryggbygg = inget att googla, Alfred = död bio-länk, Bromma = vintercopy i juni.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_