### PR TITLE
Amiri Bygg AB: CRM-lead + JA-svar (GRANIT-demon)

### DIFF
--- a/bahkobyra/dashboard/index.html
+++ b/bahkobyra/dashboard/index.html
@@ -673,6 +673,17 @@ Bara så jag förstår — ser du samma sak på din sida?
 Om det stämmer efter att du kollat kan jag visa nästa steg — helt upp till dig.</pre>
       </div>
 
+      <div class="script">
+        <div class="script-h"><span class="nm">JA-svar · Amiri Bygg AB (GRANIT-demon — ingen custom)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
+        <pre>Här är idéerna, samlade i en klickbar demo: bahkobyra.se/cloud/bygg/
+
+Öppna den i mobilen — titta bara på hur projekten presenteras och hur varje skärm leder till "Begär offert".
+
+Bara så jag förstår — får era följare något liknande när de klickar er bio-länk idag?
+
+Om inte kan jag visa nästa steg när du kollat — helt upp till dig.</pre>
+      </div>
+
     </div>
   </section>
 
@@ -1151,6 +1162,7 @@ const SEED=[
   {id:'b01',name:'Alfred Allservice',niche:'bygg',web:'https://alfredallservice.se',contact:'Fråga i DM — bolagsuppgifter ej hittbara',phone:'0380-69 20 07',email:'',city:'Nässjö',status:'Svar',notes:'IG @alfredallservice (77 följare) — POSITIVT DM-SVAR. PAIN: bio-länken död (felstavad alfredallseevice.se, finns ej i DNS) · rätt domän 0 sidor i Google-index + 403 · ingen GBP/katalogpost, numret osökbart · osynlig på snickare/badrumsrenovering nässjö (vinnare: Nässjö Golv, JB Badrum, Fallnafors, Kansjö) · 2 andra firmor heter Alfreds Allservice och äger namnet i sök. KROK: visa döda länken live i mobilen → visa demon. DEMO KLAR: bahkobyra.se/cloud/alfredallservice/ — JA-svar finns i skripten. Demo: före/efter badrum-hero + ring-knapp 0380-69 20 07. Full analys: content/leads/alfred_allservice.md',updated:today},
   {id:'b02',name:'Bromma Trädgårdsservice',niche:'bygg',web:'https://brommatradgardsservice.se',contact:'Jens Amnesten — Ägare (enskild firma, f. 1994)',phone:'',email:'jens@brommatradgardsservice.se',city:'Bromma/Västerort (säte Nacka)',status:'Svar',notes:'IG @brommatradgardsservice (1 863 följare, proffsig) — POSITIVT DM-SVAR. Firma reg. 9 jan 2026 = 5 mån gammal, uppbyggnadsfas. PAIN: Google ser bara 1 sida, title Startsida - · osynlig på trädgårdsskötsel/gräsklippning bromma · sajtcopy säljer snöröjning+fastigheter MITT I JUNI medan IG säljer villaträdgård · inga priser/RUT (konkurrenter visar från 309 kr/h) · saknas i hitta.se. KROK: 1863 följare klickar bio-länken och möts av vintercopy. Demo: säsongsavtal/ÅVS som huvuderbjudande + offertformulär + RUT-pris. DEMO KLAR: bahkobyra.se/cloud/brommatradgardsservice/ — JA-svar finns i skripten. Full analys: content/leads/bromma_tradgardsservice.md',updated:today},
   {id:'b03',name:'Tryggbyggservice',niche:'bygg',web:'',contact:'FRÅGA I DM: ort, org.nr, ägarnamn (ej verifierbart)',phone:'',email:'',city:'Okänd — fråga i DM',status:'Svar',notes:'IG @tryggbyggservice (1 074 följare, badrumsrenovering) — POSITIVT DM-SVAR. PAIN: NOLL webbnärvaro (ingen sajt/FB/GBP/katalog, IG-bion HELT TOM utan länk) · 5 namnkopior äger Google-sökningen, Trygg Bygg Skåne AB säljer samma tjänster · heter TRYGG men kan inte verifieras = köpstopp vid 100k-badrumsjobb · toppreels är TikTok-repostar med tomma captions. GULD: tryggbyggservice.se OCH .com LEDIGA — registrera dag 1 innan namnkopiorna gör det. DEMO KLAR: bahkobyra.se/cloud/tryggbyggservice/ — skicka i DM. KROK: googla namnet tillsammans på mötet. Demo: badrum före/efter-hero + trygghetssektion (org.nr/F-skatt/försäkring) + Musse Pigg-spegeln som specialsnickeri-showcase. Full analys: content/leads/tryggbyggservice.md',updated:today},
+  {id:'b04',name:'Amiri Bygg AB',niche:'bygg',web:'https://amiribyggab.se',contact:'Medi — kontakt via IG (efternamn okänt, fråga i DM)',phone:'0704-10 41 90',email:'info@amiribyggab.se',city:'Stockholm (Sundbyberg/Kungsängen enl. highlights)',status:'Svar',notes:'IG @amiribyggab.se_official (83 följare, renovering/ombyggnation/totalentreprenad + interiör/kök) — POSITIVT DM-SVAR efter budget-invändning (sa först utanför budget, tackade sen ja till idéer = skicka värde, noll pitch). PAIN: bio-länken går till WhatsApp, INTE hemsidan — domänen amiribyggab.se FINNS (DNS OK) men följare som klickar hamnar i en chatt istället för på projekten. INGEN custom-demo (värdeprincipen) — GRANIT-demon används som exempel: bahkobyra.se/cloud/bygg/. JA-svar finns i skripten.',updated:today},
 ];
 
 const CRM_KEY='bb_crm_v1';


### PR DESCRIPTION
## Vad

Fjärde positiva DM-svaret: **Amiri Bygg AB** (@amiribyggab.se_official, Stockholm — renovering/totalentreprenad/interiör). Sa först "utanför budget", tackade sen ja till idéerna — alltså JA-protokollet med ren värdeleverans, noll pitch.

## Innehåll

- **CRM b04:** kontakt "Medi" (efternamn okänt — fråga i DM), 0704-10 41 90, info@amiribyggab.se. Pain dokumenterad: bio-länken går till **WhatsApp** trots att hemsidan amiribyggab.se finns (DNS verifierad) — följare som klickar hamnar i en chatt istället för på projekten.
- **Ingen custom-demo** (värdeprincipen — credits läggs bara på kvalificerade leads): GRANIT-demon (`/cloud/bygg/`) används som exempel.
- **JA-svar enligt protokollet** i dashboardens skript — alla 4 ja-leads har nu varsitt kopierbart leveransmeddelande.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_