### PR TITLE
Alfred-demo: hero-rubriken nedskalad

### DIFF
--- a/bahkobyra/cloud/alfredallservice/index.html
+++ b/bahkobyra/cloud/alfredallservice/index.html
@@ -71,7 +71,7 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
   linear-gradient(180deg,rgba(11,11,13,.6) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
 .hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(5rem,12vh,8rem)}
 .hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
-.hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
+.hero-heading{font-family:var(--disp);font-size:clamp(2rem,6.2vw,5.4rem);font-weight:800;line-height:1.02;letter-spacing:-.01em;text-transform:uppercase;margin-bottom:1.4rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
 .hero-heading .word{display:inline-block;opacity:0;transform:translateY(60px)}
 .hero-heading .accent{background:var(--grad);background-size:220% auto;-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;animation:shimmer 7s linear infinite}
 @keyframes shimmer{to{background-position:220% center}}
@@ -184,7 +184,7 @@ footer a{color:var(--amber-lt)}
   .work-grid{grid-template-columns:1fr;gap:.9rem}
   .wcard{aspect-ratio:4/2.8}
   .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.8rem}
-  .hero-heading{font-size:clamp(2.3rem,11vw,5rem)}
+  .hero-heading{font-size:clamp(1.8rem,8vw,3.2rem)}
   .cta-button{padding:.95rem 2rem;width:100%;justify-content:center}
   #float-offert{bottom:max(1.4rem,env(safe-area-inset-bottom));right:1.4rem;font-size:.58rem;padding:.72rem 1.3rem}
   .modal{padding:1.8rem 1.4rem}


### PR DESCRIPTION
## Vad

Hero-rubriken på Alfred-demon ("Allt för hemmet. / Ett samtal bort.") tog över hela rutan — den är längre än de andra demosarnas rubriker men hade samma maxstorlek (10,5vw, vikt 900).

## Fix

- Desktop: `clamp(2.6rem,10.5vw,9.5rem)` vikt 900 → `clamp(2rem,6.2vw,5.4rem)` vikt 800, luftigare radhöjd
- Mobil: `clamp(2.3rem,11vw,5rem)` → `clamp(1.8rem,8vw,3.2rem)`

Nu syns förvandlingsvideon bakom rubriken istället för att texten dominerar. Övriga demos orörda (deras rubriker är kortare).

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_