### PR TITLE
JA-svaren v2: leadets problem invävt i varje DM

### DIFF
--- a/bahkobyra/dashboard/index.html
+++ b/bahkobyra/dashboard/index.html
@@ -645,11 +645,13 @@ ALDRIG: pitch, hype, värme-fluff, "let me know", call-push. Demo-länken levere
         <div class="script-h"><span class="nm">JA-svar · Tryggbyggservice (demo klar)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
         <pre>Hejsan!
 
+Jag testade en sak innan jag byggde demon. Googlar man Tryggbyggservice dyker fem andra byggfirmor med nästan samma namn upp, bland annat en i Skåne som gör exakt samma jobb som ni. Ni själva syns inte alls, och bion här har ingen länk.
+
 Här är demon: bahkobyra.se/cloud/tryggbyggservice/
 
-Kika på sektionen direkt under rubriken. Där ser du hur allt går att kontrollera, fast pris, vem som ansvarar och att det finns på papper.
+Kika på sektionen direkt under rubriken. Där ser man direkt att ni heter Trygg på riktigt, fast pris, vem som ansvarar och allt på papper.
 
-Bara så jag förstår, om en kund googlar er idag, hittar de något sånt?
+Bara så jag förstår, har ni märkt att kunder har svårt att hitta er när de söker på er?
 
 Om det stämmer när du kollat kan jag visa nästa steg. Helt upp till dig.
 
@@ -661,11 +663,13 @@ Mathias Bahko</pre>
         <div class="script-h"><span class="nm">JA-svar · Alfred Allservice (när demon är klar)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
         <pre>Hejsan!
 
+Innan jag byggde demon kollade jag hur man hittar er online. Länken i er bio är felstavad och leder ingenstans, och googlar man Alfred Allservice i Nässjö hamnar man hos en städfirma istället för hos er. Alla badrum och altaner ni visar här syns alltså inte där kunderna letar.
+
 Här är demon: bahkobyra.se/cloud/alfredallservice/
 
-Öppna den i mobilen. Testa sen länken i er egen Instagram-bio och se vad som händer när man klickar på den.
+Öppna den i mobilen. Testa sen er egen bio-länk och se vad som händer när man klickar på den.
 
-Bara så jag förstår, visste du att den inte leder någonstans idag?
+Bara så jag förstår, visste du om att den är felstavad idag?
 
 Om det stämmer när du kollat kan jag visa nästa steg. Helt upp till dig.
 
@@ -677,11 +681,13 @@ Mathias Bahko</pre>
         <div class="script-h"><span class="nm">JA-svar · Bromma Trädgårdsservice (när demon är klar)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
         <pre>Hejsan!
 
+Jag kikade på er sajt innan jag byggde demon. Den pratar snöröjning och fastighetsbolag mitt i juni, samtidigt som ditt flöde är fullt av villaträdgårdar, gräs och häckar. Dina 1 800+ följare som klickar på bio-länken möter alltså vinterbudskap mitt i högsäsongen.
+
 Här är demon: bahkobyra.se/cloud/brommatradgardsservice/
 
-Kika på första skärmen. Juni-läge, gräs och häckar. Jämför sen med vad dina följare möter när de klickar på din bio-länk idag.
+Kika på första skärmen. Juni-läge direkt, gräs, häckar och RUT-pris. Snöröjningen ligger kvar, men som en del av säsongsavtalet där den hör hemma.
 
-Bara så jag förstår, ser du samma sak på din sida?
+Bara så jag förstår, känner du igen bilden av att sajten och flödet säger olika saker?
 
 Om det stämmer när du kollat kan jag visa nästa steg. Helt upp till dig.
 
@@ -693,11 +699,13 @@ Mathias Bahko</pre>
         <div class="script-h"><span class="nm">JA-svar · Amiri Bygg AB (GRANIT-demon — ingen custom)</span><span class="tag">DM</span><button class="copy">Kopiera</button></div>
         <pre>Hejsan!
 
+Era kök och interiörprojekt ser riktigt genomarbetade ut i flödet. Men när någon klickar på er bio-länk hamnar de i WhatsApp istället för på projekten, så det starkaste ni har syns aldrig för den som vill kolla upp er innan de hör av sig.
+
 Här kommer idéerna, samlade i en klickbar demo: bahkobyra.se/cloud/bygg/
 
 Öppna den i mobilen och kika på hur projekten presenteras och hur varje skärm leder till en offertknapp.
 
-Bara så jag förstår, får era följare något liknande när de klickar på er bio-länk idag?
+Bara så jag förstår, är det medvetet att länken går till WhatsApp istället för till er hemsida?
 
 Om inte kan jag visa nästa steg när du kollat. Helt upp till dig.
 


### PR DESCRIPTION
## Vad

JA-svaren version 2: varje DM öppnar nu med leadets **verifierade problem** ur researchen innan demolänken, så mottagaren känner att vi faktiskt tittat på just dem. Strukturen är intakt (ett problem, en instruktion, en binär fråga, optionalitet) liksom skrivreglerna (Hejsan, inga tankstreck, Vänliga hälsningar Mathias Bahko).

## Problemen som vävts in

- **Tryggbyggservice:** fem namnkopior äger Google-sökningen, ni syns inte alls, bion saknar länk
- **Alfred:** bio-länken är felstavad och död, och namnsökningen i Nässjö leder till en städfirma
- **Bromma:** sajten pratar snöröjning och fastighetsbolag mitt i juni medan flödets 1 800+ följare ser villaträdgårdar
- **Amiri:** bio-länken går till WhatsApp istället för till projekten, trots att hemsidan finns

Verifierat: noll tankstreck i samtliga block.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_