### PR TITLE
Bahko Byrå-loggan sparad (SVG + brand.json + regel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Källdokument i `reference/`. **Allt operativt körs från dashboarden:** `bahko
 - **Cadence:** välj EN väg/lead (skriven/samtal/IRL), dag 1/3/5/7 → svar=boka, tyst=nurture/stäng.
 - **JA-protokollet (när prospekt säger ja till demo):** gör ENDAST tre saker, i ordning, lugn/mänsklig ton: 1) instruktion — "Kika på [plats] och se hur [friktion] visar sig." 2) kvalificering (binär, låg friktion) — "Bara så jag förstår, ser du samma sak på din sida idag?" 3) optionalitet — "Om det stämmer när du kollat kan jag visa nästa steg. Helt upp till dig." ALDRIG pitch, hype, värme-fluff, "let me know" eller call-push. Demo-länken levereras alltid. Full version + färdiga mallar i dashboardens Spelbok/skript.
 - **Skrivregler för alla DM/mejl till prospekt:** mänsklig, naturlig svenska — ALDRIG tankstreck (—) i meddelanden. Börja alltid med en hälsning ("Hejsan!") och avsluta alltid med "Vänliga hälsningar / Mathias Bahko".
+- **Varumärke/logga:** Bahko Byrå-loggan ligger i `bahkobyra/brand/logo.svg` (live: bahkobyra.se/brand/logo.svg, definition i `bahkobyra/brand/brand.json`) — använd ALLTID den i allt material: demos, reels, motion design, dokument. Guld-B i guldram + "Bahko *Byrå*" i Cormorant Garamond marinblå #181C38 + tagline "SYNLIGHET SOM SÄLJER". Guld #C9A96E/#E3C88E på cream #F7F3EA.
 - **Daglig blast:** volym slår allt. Flaskhals = bokade möten/vecka.
 - **Nischer:** kliniker (CRM) + bygg/tak/måleri/mark (Instagram).
 

--- a/bahkobyra/brand/brand.json
+++ b/bahkobyra/brand/brand.json
@@ -2,15 +2,28 @@
   "company_name": "Bahko Byrå",
   "tagline": "Synlighet som säljer.",
   "website": "bahkobyra.se",
-  "target_market": "Kliniker i Sverige",
-  "services": ["Hemsidor", "SEO", "Google Ads", "Social Media Ads"],
-  "primary_color": "#c9a96e",
-  "secondary_color": "#0c0a09",
-  "accent_color": "#e0c48a",
+  "target_market": "Lokala företag i Sverige (kliniker + bygg/hantverk)",
+  "services": [
+    "Hemsidor",
+    "SEO",
+    "Google Ads",
+    "Social Media Ads"
+  ],
+  "primary_color": "#C9A96E",
+  "secondary_color": "#181C38",
+  "accent_color": "#E3C88E",
   "text_color": "#f0ece4",
   "font_heading": "Cormorant Garamond",
   "font_body": "Outfit",
-  "logo_path": "brand/logo.png",
+  "logo_path": "brand/logo.svg",
   "founded": "2025",
-  "location": "Sverige"
+  "location": "Sverige",
+  "logo_url": "https://www.bahkobyra.se/brand/logo.svg",
+  "logo_description": "Guld-B i tunn guldram (kvadrat) till vänster. Ordmärke 'Bahko Byrå' i Cormorant Garamond semibold, marinblå #181C38, 'Byrå' kursivt. Tagline 'SYNLIGHET SOM SÄLJER' i Outfit, versaler, bred spärrning, gråblå #9BA0B0. Cream bakgrund #F7F3EA.",
+  "background_color": "#F7F3EA",
+  "gold_gradient": [
+    "#E3C88E",
+    "#C9A96E",
+    "#B08F4D"
+  ]
 }

--- a/bahkobyra/brand/logo.svg
+++ b/bahkobyra/brand/logo.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1560 520" role="img" aria-label="Bahko Byrå — Synlighet som säljer">
+  <title>Bahko Byrå</title>
+  <defs>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#E3C88E"/>
+      <stop offset="55%" stop-color="#C9A96E"/>
+      <stop offset="100%" stop-color="#B08F4D"/>
+    </linearGradient>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,600;1,600&amp;family=Outfit:wght@400&amp;display=swap');
+      .wordmark{font-family:'Cormorant Garamond',Georgia,serif;font-weight:600;fill:#181C38}
+      .b-mark{font-family:'Cormorant Garamond',Georgia,serif;font-weight:600}
+      .tagline{font-family:'Outfit',system-ui,sans-serif;font-weight:400;fill:#9BA0B0;letter-spacing:14px;text-transform:uppercase}
+    </style>
+  </defs>
+
+  <!-- Cream bakgrund -->
+  <rect width="1560" height="520" fill="#F7F3EA"/>
+
+  <!-- Guldram -->
+  <rect x="180" y="110" width="300" height="300" fill="none" stroke="url(#gold)" stroke-width="6"/>
+
+  <!-- Guld-B -->
+  <text class="b-mark" x="330" y="332" font-size="200" text-anchor="middle" fill="url(#gold)">B</text>
+
+  <!-- Ordmärke: Bahko (rak) + Byrå (kursiv) -->
+  <text class="wordmark" x="560" y="295" font-size="128">Bahko <tspan font-style="italic">Byrå</tspan></text>
+
+  <!-- Tagline -->
+  <text class="tagline" x="566" y="368" font-size="33">Synlighet som säljer</text>
+</svg>


### PR DESCRIPTION
## Vad

Sparar Bahko Byrå-loggan permanent i repot + varumärkesregel i minnet.

- **`brand/logo.svg`** — trogen SVG-återskapning av loggan (guld-B i tunn guldram, "Bahko *Byrå*" i Cormorant Garamond marinblå, taglinen "SYNLIGHET SOM SÄLJER" i Outfit, cream bakgrund, guldgradient). Skalbar och alltid tillgänglig på bahkobyra.se/brand/logo.svg.
- **`brand/brand.json`** — uppdaterad: logo_path pekade på en logo.png som aldrig funnits; nu logo.svg + logo_url + full beskrivning, korrigerade färger (navy #181C38, cream #F7F3EA, guldgradient) och målmarknad "lokala företag".
- **CLAUDE.md** — stående regel: loggan används ALLTID i allt material (demos, reels, motion design, dokument).

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_