### PR TITLE
Bahko brand-sting (motion-design första körningen) + lärdomar

### DIFF
--- a/.claude/skills/motion-design/SKILL.md
+++ b/.claude/skills/motion-design/SKILL.md
@@ -32,7 +32,14 @@ Den används för att attrahera och merförsälja:
 - Intake-frågor ställs med **AskUserQuestion** (inte `ask_user_input_v0`), ALLA i en enda runda (multi-question).
 - **Bildmodell: `gpt_image_2`** (verifierat ID 2026-06-12; params `quality: low/medium/high`, `resolution: 1k/2k/4k`)
   — varianterna "pro/banana/nano" finns INTE. Fallback om gpt_image_2 saknas: `nano_banana_pro`.
-- **Videomodell: `seedance_2_0`** (verifierad i scroll-cinematic-pipelinen; stödjer `start_image`, 1080p, 16:9/9:16/1:1).
+- **Videomodell: `seedance_2_0`** (verifierad i scroll-cinematic-pipelinen; stödjer `start_image`, 1080p, 16:9/9:16/1:1)
+  eller **`kling3_0`** (verifierad 2026-06-12: pro-läge 5s 9:16 ≈ 12,5 credits — mycket billigare än Seedance;
+  `mode: std/pro/4k`, `sound: on/off`, 3–15s). **KLING-KRAV (lärdom): `end_image` ENSAM ger status failed —
+  skicka ALLTID både `start_image` OCH `end_image`.** Generera en startruta (~2 credits) om en saknas,
+  och matcha referensbildernas aspect mot videons.
+- **`media_import_url` accepterar INTE SVG** (lärdom 2026-06-12) — rastrera loggan via `gpt_image_2`
+  med `brand/brand.json`-beskrivningen istället. Färdiga Bahko-rasters finns redan i brand.json
+  (`logo_raster_16x9`, `logo_raster_9x16_stacked`, `brand_sting_9x16`).
 - **Budget-preflight FÖRST:** `balance` + `get_cost:true`. Riktpris: 8s 1080p Seedance ≈ 72 credits,
   storyboard-bild ≈ 2–6 credits beroende på quality. Under 200 credits: fråga användaren innan du kör.
 - Får du `preset_recommendation`-notis: kör om bokstavligt med `declined_preset_id`.

--- a/bahkobyra/brand/brand.json
+++ b/bahkobyra/brand/brand.json
@@ -25,5 +25,8 @@
     "#E3C88E",
     "#C9A96E",
     "#B08F4D"
-  ]
+  ],
+  "brand_sting_9x16": "https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260612_154055_1c9a7798-3304-498d-9e1c-5d9b7e437775.mp4",
+  "logo_raster_16x9": "https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260612_152845_c0d6db8f-5e9c-4167-8649-deed467e4f69.png",
+  "logo_raster_9x16_stacked": "https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260612_153611_8a52f87a-dbf7-43f1-854e-2f478aa97c25.png"
 }


### PR DESCRIPTION
## Vad

Första skarpa körningen av `/motion-design`: **Bahko Byrå brand-sting** (5s, Hyper-Kinetic, 9:16, 1080p, Kling 3.0 pro) + lärdomar sparade i skillen.

## Resultat

- Storyboard (8 rutor, en grid-bild): osynlig i mörkret → guldgnista → partikelexplosion → peak-frys → skärvorna bygger guldramen → flytande guld fyller B:et → cream-ljus + ordmärke → hård logo lock med taglinen
- Video genererad med start- + slutbild, ljuddesign utan röster (whooshes + impact)
- Assets sparade i `brand/brand.json`: sting-MP4, logo-raster 16:9 + stående 9:16

## Lärdomar (inskrivna i SKILL.md)

- **kling3_0 kräver BÅDE start_image och end_image** — end ensam ger failed direkt (två bekräftade fall)
- Kling pro 5s 9:16 ≈ 12,5 credits — betydligt billigare än Seedance för stings
- `media_import_url` accepterar inte SVG — rastrera loggan via gpt_image_2 i stället

Kostnad hela körningen: ~25 credits. Saldo ~93.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_