### PR TITLE
Demo-galleri med levande förhandsvisningar + guide-videon live

### DIFF
--- a/bahkobyra/css/style.css
+++ b/bahkobyra/css/style.css
@@ -262,6 +262,25 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
 
 /* ── 14. DEMO ────────────────────────────────────────────── */
 .demo .wrap{display:grid;grid-template-columns:1.1fr 1fr;gap:clamp(2.5rem,6vw,6rem);align-items:center}
+/* Live demo-galleri */
+.demo-inner{max-width:var(--maxw);margin:0 auto;padding-left:var(--gut);padding-right:var(--gut)}
+.demo-head{max-width:640px;margin-bottom:clamp(2rem,5vw,3.2rem)}
+.demo-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:clamp(1rem,2vw,1.6rem)}
+.demo-card{display:block;border:1px solid var(--paper-line);border-radius:var(--r-lg);overflow:hidden;background:rgba(255,255,255,.02);
+  transition:transform .35s cubic-bezier(.22,1,.36,1),border-color .35s,box-shadow .35s}
+.demo-card:hover{transform:translateY(-5px);border-color:rgba(201,169,110,.45);box-shadow:0 24px 60px -24px rgba(0,0,0,.55)}
+.demo-preview{position:relative;aspect-ratio:16/11;overflow:hidden;background:#0d0b09}
+.demo-preview iframe{position:absolute;top:0;left:0;width:400%;height:400%;transform:scale(.25);transform-origin:0 0;border:0;pointer-events:none}
+.demo-shield{position:absolute;inset:0;background:linear-gradient(180deg,transparent 55%,rgba(13,11,9,.55) 100%);transition:background .35s}
+.demo-card:hover .demo-shield{background:linear-gradient(180deg,transparent 40%,rgba(13,11,9,.35) 100%)}
+.demo-card-meta{display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:1rem 1.2rem;border-top:1px solid var(--paper-line)}
+.demo-card-meta h3{font-size:1rem;font-weight:500;color:var(--paper);margin:0 0 .15rem}
+.demo-card-meta span{font-size:.72rem;color:var(--paper-45);font-weight:300}
+.demo-open{display:inline-flex;align-items:center;gap:.45rem;white-space:nowrap;color:var(--gold-lt);font-size:.68rem;font-weight:500;
+  letter-spacing:.08em;text-transform:uppercase;transition:gap .3s}
+.demo-card:hover .demo-open{gap:.8rem}
+.demo-open svg{width:13px;height:13px;stroke:currentColor;stroke-width:2;fill:none}
+.demo-proof-center{text-align:center;margin-top:clamp(1.6rem,3vw,2.4rem)}
 .demo-frame{border:1px solid var(--paper-line);border-radius:var(--r-lg);overflow:hidden;aspect-ratio:16/10;
   background:var(--navy-2);position:relative;box-shadow:0 40px 90px -40px rgba(13,16,35,.6);will-change:transform,opacity}
 .demo-frame .glow{position:absolute;inset:0;background:radial-gradient(60% 60% at 50% 40%,rgba(201,169,110,.16),transparent 70%)}
@@ -405,6 +424,8 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
   .proc-track::-webkit-scrollbar{display:none}
   .pstep{scroll-snap-align:center}
   .demo .wrap,.why .wrap{grid-template-columns:1fr}
+  .demo-grid{grid-template-columns:1fr}
+  .demo-preview{aspect-ratio:16/10}
   .audit{grid-template-columns:1fr}
   .foot-top{flex-direction:column;align-items:flex-start}
   .foot-cta{text-align:left}

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -197,27 +197,39 @@
 
 <!-- DEMO -->
 <section class="dark demo" id="demo">
-  <div class="wrap">
-    <div data-parallax="40">
-      <div class="demo-frame">
-        <div class="glow"></div>
-        <div class="demo-mock">
-          <div class="demo-dots"><i></i><i></i><i></i></div>
-          <div class="demo-bar a"></div><div class="demo-bar b"></div><div class="demo-bar c"></div><div class="demo-bar d"></div>
-          <div class="demo-lbl">Élara · Live Demo</div>
-        </div>
-      </div>
-    </div>
-    <div>
-      <span class="eyebrow">Live Demo</span>
+  <div class="demo-inner">
+    <div class="demo-head">
+      <span class="eyebrow">Live Demos</span>
       <h2 class="h2" data-lines style="margin-top:1.1rem">
         <span class="line"><span>Se hur din hemsida</span></span>
         <span class="line"><span>kan se ut <em>— nu.</em></span></span>
       </h2>
-      <p class="lede" data-reveal style="margin-top:1.4rem">Vi bygger ett fullständigt demo innan du bestämmer dig. Se bokningssystem, animationer och design i verklighet — inte i mockups.</p>
-      <a href="https://www.bahkobyra.se/cloud/" target="_blank" rel="noopener" class="demo-link magnetic" data-magnetic=".25" data-reveal>Öppna Demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></a>
-      <p class="demo-proof" data-reveal="0.1">Senaste skarpa leverans: <a href="https://maykaskitchen.se" target="_blank" rel="noopener">maykaskitchen.se</a></p>
+      <p class="lede" data-reveal style="margin-top:1.4rem">Vi bygger ett fullständigt demo innan du bestämmer dig. Klicka in i tre av våra senaste — riktiga sajter med bokning, animationer och design i verklighet. Inte mockups.</p>
     </div>
+    <div class="demo-grid">
+      <a class="demo-card" href="https://www.bahkobyra.se/cloud/" target="_blank" rel="noopener" data-reveal aria-label="Öppna demo: Élara Klinik">
+        <div class="demo-preview"><iframe src="https://www.bahkobyra.se/cloud/" loading="lazy" tabindex="-1" aria-hidden="true" title="Förhandsvisning Élara Klinik"></iframe><div class="demo-shield"></div></div>
+        <div class="demo-card-meta">
+          <div><h3>Élara Klinik</h3><span>Estetisk klinik · Scroll-upplevelse</span></div>
+          <span class="demo-open">Öppna demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+        </div>
+      </a>
+      <a class="demo-card" href="https://www.bahkobyra.se/cloud/bygg/" target="_blank" rel="noopener" data-reveal="0.08" aria-label="Öppna demo: GRANIT Bygg &amp; Entreprenad">
+        <div class="demo-preview"><iframe src="https://www.bahkobyra.se/cloud/bygg/" loading="lazy" tabindex="-1" aria-hidden="true" title="Förhandsvisning GRANIT Bygg"></iframe><div class="demo-shield"></div></div>
+        <div class="demo-card-meta">
+          <div><h3>GRANIT Bygg</h3><span>Bygg &amp; entreprenad · Husförvandling</span></div>
+          <span class="demo-open">Öppna demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+        </div>
+      </a>
+      <a class="demo-card" href="https://www.bahkobyra.se/cloud/brommatradgardsservice/" target="_blank" rel="noopener" data-reveal="0.16" aria-label="Öppna demo: Bromma Trädgårdsservice">
+        <div class="demo-preview"><iframe src="https://www.bahkobyra.se/cloud/brommatradgardsservice/" loading="lazy" tabindex="-1" aria-hidden="true" title="Förhandsvisning Bromma Trädgårdsservice"></iframe><div class="demo-shield"></div></div>
+        <div class="demo-card-meta">
+          <div><h3>Bromma Trädgård</h3><span>Trädgårdsskötsel · Säsongsavtal</span></div>
+          <span class="demo-open">Öppna demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+        </div>
+      </a>
+    </div>
+    <p class="demo-proof demo-proof-center" data-reveal="0.1">Senaste skarpa leverans: <a href="https://maykaskitchen.se" target="_blank" rel="noopener">maykaskitchen.se</a></p>
   </div>
 </section>
 

--- a/bahkobyra/kliniker/gratis-guide.html
+++ b/bahkobyra/kliniker/gratis-guide.html
@@ -182,16 +182,7 @@
     <!-- VIDEO -->
     <div class="video-wrap">
       <div class="video-frame">
-        <!-- ====================================================================
-             BYT UT placeholdern nedan mot din inspelade video.
-             YouTube (olistad):  <iframe src="https://www.youtube.com/embed/DITT_ID" title="..." allowfullscreen></iframe>
-             Loom:               <iframe src="https://www.loom.com/embed/DITT_ID" allowfullscreen></iframe>
-             Manus att spela in finns i: kliniker/gratis-guide-video-manus.md (i repot)
-        ===================================================================== -->
-        <div class="video-ph">
-          <span class="play">▶</span>
-          <span>Din video läggs här (se kommentar i koden)</span>
-        </div>
+        <iframe src="https://www.youtube-nocookie.com/embed/dKu5JzmaGRU" title="3 sätt att ranka högre på Google — Bahko Byrå" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
       </div>
     </div>
 


### PR DESCRIPTION
## Vad

Två uppdateringar på bahkobyra.se:

**1. Live Demo-sektionen → demo-galleri med levande förhandsvisningar**
- Den gamla mockup-attrappen (streck-baren) ersatt med **tre klickbara kort**: Élara Klinik (`/cloud/`), GRANIT Bygg (`/cloud/bygg/`) och Bromma Trädgård (`/cloud/brommatradgardsservice/`)
- Varje kort visar **den riktiga sajten** i en skalad lazy-iframe — demosajternas videoloopar autoplayar, så miniatyrerna lever
- Hela kortet är länk (öppnas i ny flik), hover-lyft + guldkant, namn/nisch i kortfoten, 1 kolumn på mobil
- maykaskitchen.se-beviset ligger kvar centrerat under griden

**2. Guide-videon är live**
- `kliniker/gratis-guide.html`: placeholdern ersatt med YouTube-embedden (dKu5JzmaGRU, youtube-nocookie, lazy) — sista pending-punkten för guide-sidan är därmed klar

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_