### PR TITLE
Fix iOS-krasch på startsidan: demo-iframes → statiska bilder

### DIFF
--- a/bahkobyra/css/style.css
+++ b/bahkobyra/css/style.css
@@ -270,7 +270,8 @@ section{padding-top:var(--section);padding-bottom:var(--section)}
   transition:transform .35s cubic-bezier(.22,1,.36,1),border-color .35s,box-shadow .35s}
 .demo-card:hover{transform:translateY(-5px);border-color:rgba(201,169,110,.45);box-shadow:0 24px 60px -24px rgba(0,0,0,.55)}
 .demo-preview{position:relative;aspect-ratio:16/11;overflow:hidden;background:#0d0b09}
-.demo-preview iframe{position:absolute;top:0;left:0;width:400%;height:400%;transform:scale(.25);transform-origin:0 0;border:0;pointer-events:none}
+.demo-preview img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform .6s cubic-bezier(.22,1,.36,1)}
+.demo-card:hover .demo-preview img{transform:scale(1.05)}
 .demo-shield{position:absolute;inset:0;background:linear-gradient(180deg,transparent 55%,rgba(13,11,9,.55) 100%);transition:background .35s}
 .demo-card:hover .demo-shield{background:linear-gradient(180deg,transparent 40%,rgba(13,11,9,.35) 100%)}
 .demo-card-meta{display:flex;align-items:center;justify-content:space-between;gap:1rem;padding:1rem 1.2rem;border-top:1px solid var(--paper-line)}

--- a/bahkobyra/index.html
+++ b/bahkobyra/index.html
@@ -208,21 +208,21 @@
     </div>
     <div class="demo-grid">
       <a class="demo-card" href="https://www.bahkobyra.se/cloud/" target="_blank" rel="noopener" data-reveal aria-label="Öppna demo: Élara Klinik">
-        <div class="demo-preview"><iframe src="https://www.bahkobyra.se/cloud/" loading="lazy" tabindex="-1" aria-hidden="true" title="Förhandsvisning Élara Klinik"></iframe><div class="demo-shield"></div></div>
+        <div class="demo-preview"><img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260605_175414_19e0ded6-db4c-4a70-b773-3bef424f774f.png" alt="Förhandsvisning Élara Klinik" loading="lazy"><div class="demo-shield"></div></div>
         <div class="demo-card-meta">
           <div><h3>Élara Klinik</h3><span>Estetisk klinik · Scroll-upplevelse</span></div>
           <span class="demo-open">Öppna demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
         </div>
       </a>
       <a class="demo-card" href="https://www.bahkobyra.se/cloud/bygg/" target="_blank" rel="noopener" data-reveal="0.08" aria-label="Öppna demo: GRANIT Bygg &amp; Entreprenad">
-        <div class="demo-preview"><iframe src="https://www.bahkobyra.se/cloud/bygg/" loading="lazy" tabindex="-1" aria-hidden="true" title="Förhandsvisning GRANIT Bygg"></iframe><div class="demo-shield"></div></div>
+        <div class="demo-preview"><img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_182740_5c48f715-f0c5-4357-9d90-7e9f50c4a596.png" alt="Förhandsvisning GRANIT Bygg" loading="lazy"><div class="demo-shield"></div></div>
         <div class="demo-card-meta">
           <div><h3>GRANIT Bygg</h3><span>Bygg &amp; entreprenad · Husförvandling</span></div>
           <span class="demo-open">Öppna demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
         </div>
       </a>
       <a class="demo-card" href="https://www.bahkobyra.se/cloud/brommatradgardsservice/" target="_blank" rel="noopener" data-reveal="0.16" aria-label="Öppna demo: Bromma Trädgårdsservice">
-        <div class="demo-preview"><iframe src="https://www.bahkobyra.se/cloud/brommatradgardsservice/" loading="lazy" tabindex="-1" aria-hidden="true" title="Förhandsvisning Bromma Trädgårdsservice"></iframe><div class="demo-shield"></div></div>
+        <div class="demo-preview"><img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222907_abd794d7-4c74-4996-b84a-0c8efd723860.png" alt="Förhandsvisning Bromma Trädgård" loading="lazy"><div class="demo-shield"></div></div>
         <div class="demo-card-meta">
           <div><h3>Bromma Trädgård</h3><span>Trädgårdsskötsel · Säsongsavtal</span></div>
           <span class="demo-open">Öppna demo <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>


### PR DESCRIPTION
## Problemet

iOS Safari kraschade startsidan med "Ett problem inträffade flera gånger" efter ~30 sekunder (bara iPhone, inte Android). Det är WebKits minnesbrist-krasch.

## Orsak

Demo-galleriet (PR #49) laddade tre **live-iframes** på startsidan, där varje iframe är en komplett demosajt med egna GSAP/Lenis-script och autoplay-videor. GRANIT och Bromma har två videor var = fyra videoavkodare igång samtidigt, ovanpå startsidans YouTube-hero och egna animationer. iOS har hårda gränser för minne och samtidiga videoavkodare per flik; Android är mer förlåtande. Därav iOS-specifik krasch efter att minnet byggts upp.

## Fix

Korten visar nu **statiska hjältebilder** (samma renders som demosarnas hero: Élara-after, GRANIT-drömhuset, Bromma-trädgården) som länkar vidare till respektive demo. Hover-zoom behålls för liv. Noll extra video eller JS-runtime på startsidan, bara tre bilder.

Verifierat: inga demo-iframes kvar, YouTube-heron är nu enda iframen på sidan.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_