### PR TITLE
Fix: demos fastnade på laddskärm (jsdelivr → cloudflare CDN)

### DIFF
--- a/bahkobyra/cloud/alfredallservice/index.html
+++ b/bahkobyra/cloud/alfredallservice/index.html
@@ -190,6 +190,11 @@ footer a{color:var(--amber-lt)}
   .modal{padding:1.8rem 1.4rem}
   .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
 }
+html.fallback #loader{display:none}
+html.fallback #scroll-container{height:auto}
+html.fallback .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll-indicator{opacity:1!important}
+html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
   #loader{display:none}
@@ -396,12 +401,15 @@ footer a{color:var(--amber-lt)}
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
 <script>
 (function(){
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const htmlEl=document.documentElement, loaderEl=document.getElementById('loader');
+  function goStatic(){htmlEl.classList.add('fallback');if(loaderEl)loaderEl.classList.add('hidden');if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});}
+  const failsafe=setTimeout(goStatic,3500);
 
   // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
   function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
@@ -410,17 +418,19 @@ footer a{color:var(--amber-lt)}
 
   if(reduce){
     document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
-    document.getElementById('loader').classList.add('hidden');
+    clearTimeout(failsafe);goStatic();
     return;
   }
-  if(typeof gsap==='undefined')return;
+  if(typeof gsap==='undefined'){clearTimeout(failsafe);goStatic();return;}
   gsap.registerPlugin(ScrollTrigger);
 
-  // ===== LENIS =====
-  const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
-  lenis.on('scroll',ScrollTrigger.update);
-  gsap.ticker.add(t=>lenis.raf(t*1000));
-  gsap.ticker.lagSmoothing(0);
+  // ===== LENIS (valfri — demon funkar utan smooth scroll om CDN:en blockeras) =====
+  if(typeof Lenis!=='undefined'){
+    const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+    lenis.on('scroll',ScrollTrigger.update);
+    gsap.ticker.add(t=>lenis.raf(t*1000));
+    gsap.ticker.lagSmoothing(0);
+  }
 
   // ===== LOADER =====
   const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
@@ -429,7 +439,7 @@ footer a{color:var(--amber-lt)}
     loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
     loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
     if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
-    else{setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
   })();
 
   // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====

--- a/bahkobyra/cloud/brommatradgardsservice/index.html
+++ b/bahkobyra/cloud/brommatradgardsservice/index.html
@@ -190,6 +190,11 @@ footer a{color:var(--amber-lt)}
   .modal{padding:1.8rem 1.4rem}
   .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
 }
+html.fallback #loader{display:none}
+html.fallback #scroll-container{height:auto}
+html.fallback .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll-indicator{opacity:1!important}
+html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
   #loader{display:none}
@@ -396,12 +401,15 @@ footer a{color:var(--amber-lt)}
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
 <script>
 (function(){
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const htmlEl=document.documentElement, loaderEl=document.getElementById('loader');
+  function goStatic(){htmlEl.classList.add('fallback');if(loaderEl)loaderEl.classList.add('hidden');if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});}
+  const failsafe=setTimeout(goStatic,3500);
 
   // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
   function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
@@ -410,17 +418,19 @@ footer a{color:var(--amber-lt)}
 
   if(reduce){
     document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
-    document.getElementById('loader').classList.add('hidden');
+    clearTimeout(failsafe);goStatic();
     return;
   }
-  if(typeof gsap==='undefined')return;
+  if(typeof gsap==='undefined'){clearTimeout(failsafe);goStatic();return;}
   gsap.registerPlugin(ScrollTrigger);
 
-  // ===== LENIS =====
-  const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
-  lenis.on('scroll',ScrollTrigger.update);
-  gsap.ticker.add(t=>lenis.raf(t*1000));
-  gsap.ticker.lagSmoothing(0);
+  // ===== LENIS (valfri — demon funkar utan smooth scroll om CDN:en blockeras) =====
+  if(typeof Lenis!=='undefined'){
+    const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+    lenis.on('scroll',ScrollTrigger.update);
+    gsap.ticker.add(t=>lenis.raf(t*1000));
+    gsap.ticker.lagSmoothing(0);
+  }
 
   // ===== LOADER =====
   const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
@@ -429,7 +439,7 @@ footer a{color:var(--amber-lt)}
     loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
     loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
     if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
-    else{setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
   })();
 
   // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====

--- a/bahkobyra/cloud/bygg/index.html
+++ b/bahkobyra/cloud/bygg/index.html
@@ -190,6 +190,11 @@ footer a{color:var(--amber-lt)}
   .modal{padding:1.8rem 1.4rem}
   .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
 }
+html.fallback #loader{display:none}
+html.fallback #scroll-container{height:auto}
+html.fallback .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll-indicator{opacity:1!important}
+html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
   #loader{display:none}
@@ -395,12 +400,15 @@ footer a{color:var(--amber-lt)}
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
 <script>
 (function(){
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const htmlEl=document.documentElement, loaderEl=document.getElementById('loader');
+  function goStatic(){htmlEl.classList.add('fallback');if(loaderEl)loaderEl.classList.add('hidden');if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});}
+  const failsafe=setTimeout(goStatic,3500);
 
   // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
   function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
@@ -409,17 +417,19 @@ footer a{color:var(--amber-lt)}
 
   if(reduce){
     document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
-    document.getElementById('loader').classList.add('hidden');
+    clearTimeout(failsafe);goStatic();
     return;
   }
-  if(typeof gsap==='undefined')return;
+  if(typeof gsap==='undefined'){clearTimeout(failsafe);goStatic();return;}
   gsap.registerPlugin(ScrollTrigger);
 
-  // ===== LENIS =====
-  const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
-  lenis.on('scroll',ScrollTrigger.update);
-  gsap.ticker.add(t=>lenis.raf(t*1000));
-  gsap.ticker.lagSmoothing(0);
+  // ===== LENIS (valfri — demon funkar utan smooth scroll om CDN:en blockeras) =====
+  if(typeof Lenis!=='undefined'){
+    const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+    lenis.on('scroll',ScrollTrigger.update);
+    gsap.ticker.add(t=>lenis.raf(t*1000));
+    gsap.ticker.lagSmoothing(0);
+  }
 
   // ===== LOADER =====
   const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
@@ -428,7 +438,7 @@ footer a{color:var(--amber-lt)}
     loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
     loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
     if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
-    else{setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
   })();
 
   // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====

--- a/bahkobyra/cloud/index.html
+++ b/bahkobyra/cloud/index.html
@@ -191,6 +191,14 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 
 
 /* ===== MOBILE ===== */
+html.fallback #loader{display:none}
+html.fallback #scroll-container{height:auto}
+html.fallback .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll-indicator{opacity:1!important}
+html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
+html.fallback .align-left,html.fallback .align-right{padding-left:5vw;padding-right:5vw}
+html.fallback .align-left .section-inner,html.fallback .align-right .section-inner{max-width:100%}
+html.fallback .marquee-wrap{display:none}
 @media(max-width:768px){
   .header-nav{display:none}
   .hamburger{display:flex}
@@ -418,17 +426,23 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
 <script>
 (function(){
   "use strict";
+  const htmlEl=document.documentElement, loaderEl=document.getElementById("loader");
+  function goStatic(){htmlEl.classList.add("fallback");if(loaderEl)loaderEl.classList.add("hidden");}
+  const failsafe=setTimeout(goStatic,3500);
+  if(typeof gsap==="undefined"){clearTimeout(failsafe);goStatic();return;}
 
-  // ===== LENIS =====
-  const lenis = new Lenis({ duration:1.15, easing:t=>1-Math.pow(1-t,3), smoothWheel:true, syncTouch:true, touchMultiplier:1.5 });
-  lenis.on("scroll", ScrollTrigger.update);
-  gsap.ticker.add(time => lenis.raf(time*1000));
-  gsap.ticker.lagSmoothing(0);
+  // ===== LENIS (valfri) =====
+  if(typeof Lenis!=="undefined"){
+    const lenis = new Lenis({ duration:1.15, easing:t=>1-Math.pow(1-t,3), smoothWheel:true, syncTouch:true, touchMultiplier:1.5 });
+    lenis.on("scroll", ScrollTrigger.update);
+    gsap.ticker.add(time => lenis.raf(time*1000));
+    gsap.ticker.lagSmoothing(0);
+  }
 
   // ===== CANVAS =====
   const canvas = document.getElementById("canvas");
@@ -466,7 +480,7 @@ body{background:var(--bg);color:var(--text-primary);font-family:var(--font-body)
     loadProg+=Math.random()*12+3; if(loadProg>100)loadProg=100;
     loaderBar.style.width=loadProg+"%"; loaderPct.textContent=Math.round(loadProg)+"%";
     if(loadProg<100){setTimeout(simulateLoad,80+Math.random()*120);}
-    else{setTimeout(()=>{loader.classList.add("hidden");animateHero();drawAmbient(0);},400);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add("hidden");animateHero();drawAmbient(0);},400);}
   }
   simulateLoad();
 

--- a/bahkobyra/cloud/tryggbyggservice/index.html
+++ b/bahkobyra/cloud/tryggbyggservice/index.html
@@ -190,6 +190,11 @@ footer a{color:var(--amber-lt)}
   .modal{padding:1.8rem 1.4rem}
   .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
 }
+html.fallback #loader{display:none}
+html.fallback #scroll-container{height:auto}
+html.fallback .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll-indicator{opacity:1!important}
+html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
   #loader{display:none}
@@ -396,12 +401,15 @@ footer a{color:var(--amber-lt)}
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
 <script>
 (function(){
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const htmlEl=document.documentElement, loaderEl=document.getElementById('loader');
+  function goStatic(){htmlEl.classList.add('fallback');if(loaderEl)loaderEl.classList.add('hidden');if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});}
+  const failsafe=setTimeout(goStatic,3500);
 
   // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
   function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
@@ -410,17 +418,19 @@ footer a{color:var(--amber-lt)}
 
   if(reduce){
     document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
-    document.getElementById('loader').classList.add('hidden');
+    clearTimeout(failsafe);goStatic();
     return;
   }
-  if(typeof gsap==='undefined')return;
+  if(typeof gsap==='undefined'){clearTimeout(failsafe);goStatic();return;}
   gsap.registerPlugin(ScrollTrigger);
 
-  // ===== LENIS =====
-  const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
-  lenis.on('scroll',ScrollTrigger.update);
-  gsap.ticker.add(t=>lenis.raf(t*1000));
-  gsap.ticker.lagSmoothing(0);
+  // ===== LENIS (valfri — demon funkar utan smooth scroll om CDN:en blockeras) =====
+  if(typeof Lenis!=='undefined'){
+    const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+    lenis.on('scroll',ScrollTrigger.update);
+    gsap.ticker.add(t=>lenis.raf(t*1000));
+    gsap.ticker.lagSmoothing(0);
+  }
 
   // ===== LOADER =====
   const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
@@ -429,7 +439,7 @@ footer a{color:var(--amber-lt)}
     loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
     loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
     if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
-    else{setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
   })();
 
   // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====

--- a/content/cold-call/cold-call-har-hemsida.md
+++ b/content/cold-call/cold-call-har-hemsida.md
@@ -1,0 +1,72 @@
+# Cold call — prospekt som REDAN har en hemsida
+
+Mål: inte stänga på samtalet. Få ett ja till ett gratis hemsideförslag (demo) de får titta på.
+Säljer HEMSIDOR. Aldrig "Växa på Google"/SEO-copy. Pris hör hemma i skriftlig offert, inte i samtalet.
+
+## Manus (bullets)
+
+**Öppning (pattern interrupt + ärlighet + tillstånd)**
+- "Hejsan, det är Mathias från Bahko Byrå. Jag ska vara helt ärlig, det här är ett kallt samtal."
+- "Får jag 20 sekunder att förklara varför jag ringer, sen får du avgöra om det är intressant?"
+- (Ärligheten avväpnar. Vänta på "ja".)
+
+**Anledning (en konkret observation om DERAS sida)**
+- "Jag kikade på er hemsida innan jag ringde och såg en grej som troligen kostar er kunder."
+- En specifik sak: "bokningsknappen är svår att hitta i mobilen" / "sidan laddar långsamt" / "man
+  ser inte era jobb direkt" / "det är otydligt vad man ska göra när man landar där".
+- Aldrig svepande ("er sida är dålig"). Alltid EN konkret, sann observation.
+
+**Reframe (de HAR en sida — sänk garden)**
+- "Ni har ju redan en sida, så det är inte det jag säljer."
+- "Grejen är att en sida, och en sida som faktiskt drar in kunder, är två helt olika saker."
+- "Er sida är en säljare som jobbar dygnet runt. Frågan är bara om den säljer eller skrämmer bort."
+
+**De två frågorna (discovery — se nedan)**
+- Ställ fråga 1, lyssna. Ställ fråga 2, lyssna. Låt tystnaden göra jobbet.
+
+**Erbjudande (front offer, Easy YES)**
+- "Det jag kan göra, helt gratis, är att bygga ett förslag på hur er sida kan se ut istället."
+- "Du ser skillnaden svart på vitt i mobilen, sen bestämmer du helt själv. Låter det okej?"
+
+**När de säger ja**
+- "Perfekt. Jag skickar en demo inom 48 timmar. Vilket nummer / vilken mejl når jag dig bäst på?"
+- Leverera sen enligt JA-protokollet (kika på [plats] → "ser du samma sak?" → optionalitet).
+
+**Avslut om nej / fel timing**
+- "Helt okej, tack för att du tog samtalet. Får jag skicka förslaget ändå, så har du det den dag
+  det blir aktuellt?" (mjuk, lämna dörren öppen, aldrig övertala)
+
+**Invändningar (kort)**
+- "Vi har redan en sida": det ÄR utgångspunkten, se reframe. "Just därför ringer jag, jag vill visa
+  hur samma sida kan dra in fler jobb."
+- "Har inte tid": "Förstår, 20 sekunder bara, sen släpper jag dig." / boka återkomst.
+- "Vad kostar det": "Det beror på sidan, det får du svart på vitt i en offert. Men förslaget kostar
+  ingenting, ska jag bygga det?" (flytta pris till skriftlig offert)
+
+---
+
+## Hur vi säljer in det när de redan har en sida
+
+- **Attackera aldrig sidan.** De har lagt pengar och stolthet i den. Ego + sunk cost = stängd dörr.
+- **Sälj inte "en hemsida". Sälj fler kunder.** Sidan är bara mekanismen. Resultatet är bokningar.
+- **Reframe: "ha en sida" ≠ "ha en sida som säljer".** De flesta sidor är en digital broschyr som
+  ligger död. Vi gör den till en säljare.
+- **Peka på EN konkret läcka, inte tio.** En specifik sak de själva kan se ("svårt att boka i mobilen")
+  skapar en aha, tio saker skapar försvar.
+- **Visa, berätta inte.** Front offer = ett gratis förslag de SER bredvid sin nuvarande sida.
+  Kontrasten säljer åt dig. Du behöver inte övertyga, bara visa.
+- **Gör risken noll.** Gratis, inget krav, du bestämmer sen. Easy YES.
+
+---
+
+## De två frågorna (discovery)
+
+1. **"Om en ny kund landar på er sida idag, vad vill du att de ska göra där?"**
+   → De flesta kan inte svara tydligt. Det blottar att sidan saknar ett mål/tydlig CTA. Gapet öppnar sig.
+
+2. **"Hur många kunder skulle du gissa hör av sig via hemsidan i månaden?"**
+   → Svaret är nästan alltid "få" eller "vet inte". Då äger de själva problemet, du behöver inte säga det.
+   Följdfråga: "Och hur många skulle du vilja att det var?" (skapar gapet mellan nu och önskat läge)
+
+> Poängen med frågorna: få DEM att säga att sidan inte drar in jobb. Säljer du det själv blir det en
+> invändning. Säger de det själva blir det en sanning de vill lösa.

--- a/content/cold-call/ringlista-bygg-utan-hemsida-2.md
+++ b/content/cold-call/ringlista-bygg-utan-hemsida-2.md
@@ -1,0 +1,71 @@
+# Ringlista 2 — 10 bygg/hantverk utan hemsida (cold call)
+
+Researchad 2026-06-16 via webbsök (hitta.se/eniro/allabolag/ratsit). Alla VERKLIGA firmor, nya orter (ingen
+överlapp med ringlista 1). **Verifiera per lead innan du ringer (10 sek):** googla namnet → ingen
+"Webbplats"-knapp i Google/Maps-rutan = ingen sajt. Bekräfta numret i hitta.se (snippet-nr kan vara avkortade).
+Front offer: gratis hemsideförslag de får se. Säljer hemsidor, pris i offert. ✅ = komplett nummer i källa.
+
+---
+
+## Komplett telefonnummer (ring direkt efter snabb-koll)
+
+**1. Abbekås Allservice — Ystad** (Bertil Rahm, firma sedan 1991) · **0411-53 00 25** ✅
+- Problem: "Hej, är det Bertil? Ni har funnits sedan 90-talet och har säkert gott rykte i Ystad. Men en ny
+  kund som googlar er hittar ingenting, då går de till nästa. 30 års rykte som inte syns online."
+- Lösning: Enkel sida som fångar upp ert rykte och visar jobben, så nya kunder hittar er.
+
+**2. Murar'n i Gustafs AB — Borlänge** (murare/puts) · **070-295 14 10** ✅
+- Problem: "Murning väljer man med ögonen. Idag finns inga bilder på era jobb när någon söker murare i
+  Borlänge, ni konkurrerar blint mot dem som visar sina."
+- Lösning: Sida med galleri av era mur- och putsjobb så kunden ser kvaliteten direkt.
+
+**3. Snickare M Johansson — Degerfors** (snickeri/bygg) · **070-218 07 83** (även 0586-427 99) ✅
+- Problem: "När någon i Degerfors söker en snickare syns ni inte, bara en katalograd. Kunden som vill se
+  vad ni byggt hittar ingenting."
+- Lösning: Sida som visar era snickerijobb och gör det lätt att begära offert.
+
+**4. Stig Eriksson Byggservice — Kristinehamn** (bygg) · **070-357 74 52** ✅
+- Problem: "Hej Stig. Innan en kund släpper in en byggare i hemmet kollar de upp er. Finns inget att
+  hitta ringer de nästa, oavsett hur bra ni är."
+- Lösning: Sida med referenser och jobb som ger trygghet svart på vitt.
+
+**5. Micke Målare — Kristinehamn** (Mikael "Micke" Johansson, måleri) · **070-542 52 10** ✅
+- Problem: "Hej Micke. Måleri är ren före/efter, kunden väljer med ögonen. Men det finns inte en bild på
+  era jobb online, ni tappar kunder till målare som visar sina."
+- Lösning: Sida med före/efter-galleri som säljer åt er.
+
+## Namngiven kontakt — verifiera numret i hitta.se först
+
+**6. Hje Byggservice — Storvreta/Uppsala** (Jimmy Eriksson, goda omdömen) · kolla hitta.se
+- Problem: "Hej Jimmy. Ni har bra omdömen, men de ligger utspridda och egen sida saknas. En kund som
+  googlar er hittar inte ert rykte samlat någonstans."
+- Lösning: Sida som samlar omdömen, jobb och kontakt på ett ställe.
+
+**7. Sjöholm & Gustafsson Bygg & Kakel — Helsingborg** (Tony Gustafsson) · 076-853 59… (kolla hitta.se)
+- Problem: "Hej Tony. Kakel och badrum är dyra jobb där kunden vill se att ni gjort det förut. Idag finns
+  inga bilder, bara en katalograd, då väljer de den som visar sina badrum."
+- Lösning: Sida med badrums-/kakelgalleri + begär offert.
+
+**8. Linds snickeri och bygg — Filipstad** (Robert Lind) · 070-699 63 XX (kolla hitta.se)
+- Problem: "Hej Robert. Snickeri är hantverk man vill se. När någon söker snickare i Filipstad finns ni
+  inte, bara en katalograd."
+- Lösning: Sida som visar era snickerijobb så rätt kunder hör av sig.
+
+**9. Astrand Projekt — Katrineholm** (snickeri/ROT) · kolla hitta.se
+- Problem: "Ni gör ROT och snickeri men är helt osynliga när någon i Katrineholm söker. Kunden hittar
+  konkurrenterna först." (extra starkt: två kataloger flaggar uttryckligen 'ingen webbsida')
+- Lösning: Sida som äger ert namn på Google och visar era jobb.
+
+**10. Byggbolaget i Motala — Motala** (Trajche Ristov, byggsnickeri) · kolla hitta.se
+- Problem: "Hej, är det Trajche? En kund som vill kolla upp er innan de hör av sig hittar bara en
+  katalogsida, inte er. Det skapar tvekan precis när de ska bestämma sig."
+- Lösning: Sida som visar vilka ni är och vad ni gör, så kunden vågar ringa.
+
+---
+
+## Gemensam kärna (säg alltid)
+De har bevisat hantverket, de saknar bara skyltfönstret. En sida = en säljare dygnet runt. Front offer:
+"Jag bygger ett gratis förslag på hur er sida kan se ut, du ser skillnaden och bestämmer sen. Låter det
+okej?" → JA-protokollet (kika på [plats] → "ser du samma sak?" → optionalitet). Pris i offert, aldrig i samtalet.
+
+Hitta fler själv: se Google Maps-metoden i `ringlista-bygg-utan-hemsida.md`.

--- a/content/cold-call/ringlista-bygg-utan-hemsida.md
+++ b/content/cold-call/ringlista-bygg-utan-hemsida.md
@@ -1,0 +1,69 @@
+# Ringlista — 5 bygg/hantverk utan hemsida (cold call)
+
+Researchad 2026-06-16 via webbsök (hitta.se/eniro/allabolag/ratsit). Alla är VERKLIGA firmor.
+**Verifiera per lead innan du ringer (10 sek):** googla namnet → finns ingen "Webbplats"-knapp i
+Google/Maps-rutan = ingen sajt. Bekräfta telefonnumret i hitta.se (snippet-nummer kan vara avkortade).
+Front offer i alla samtal: gratis hemsideförslag de får se. Säljer hemsidor, pris i offert.
+
+---
+
+## 1. H&S Plattsättare — Södertälje
+- **Trade:** Plattsättning (golv & vägg) · enskild firma sedan 2022
+- **Telefon:** 072-925 15 26 (komplett i eniro/hitta)
+- **Ingen hemsida:** syns bara på katalogsajter, ingen egen domän
+- **PROBLEM-vinkel:** "Ett badrum är bland det dyraste en kund köper, och det första de vill göra är
+  att SE att ni gjort det förut. Idag, när någon googlar er, finns inga bilder på era jobb, bara en
+  katalograd. Då väljer de plattsättaren som visar sitt hantverk."
+- **LÖSNING:** En enkel sida med ett galleri av era plattsättningsjobb + tydlig 'begär offert', så
+  kunden ser kvaliteten och vågar boka direkt.
+
+## 2. Eksjö Platt & Murning — Eksjö (kontakt: Mats Utterström)
+- **Trade:** Plattsättning & murning
+- **Telefon:** 070-595 94 69 (komplett i snippet)
+- **Ingen hemsida:** bara kataloger, använder hotmail-adress (hårt bevis på ingen egen domän)
+- **PROBLEM-vinkel:** "Hej, är det Mats? Ni har ju ett bra rykte i Eksjö, men det stannar i Eksjö.
+  En ny kund som googlar 'plattsättare Eksjö' hittar er inte, bara konkurrenterna. Ert rykte jobbar
+  inte åt er online."
+- **LÖSNING:** En sida som äger ert namn på Google och visar era jobb, så att rekommendationerna
+  faktiskt landar hos er istället för att läcka.
+
+## 3. Darek Bygg & Städ — Kungälv/Ytterby (kontakt: Dariusz "Darek" Kalinowski)
+- **Trade:** Byggservice/snickeri (badrum, tak, fönsterbyte, kök, mark) · enskild firma
+- **Telefon:** 073-957 35 74 (komplett i hitta/eniro)
+- **Ingen hemsida:** bara kataloger, använder gmail (dkbygg...@gmail.com = tydligt ingen domän)
+- **PROBLEM-vinkel:** "Hej Darek. Ni gör ju allt från badrum till tak, men när någon i Kungälv söker
+  en byggare finns det inget som visar bredden. En kund som vill kolla upp er innan de släpper in er
+  i hemmet hittar bara en katalogsida, inte er."
+- **LÖSNING:** En sida som visar hela bredden + referenser, så att kunden ser att ni klarar jobbet
+  och vågar höra av sig.
+
+## 4. Hasse Eriksson Måleri — Solna
+- **Trade:** Måleri · enskild firma
+- **Telefon:** 08-560 405... (avkortat i snippet — KOLLA hitta.se för fullständigt nr)
+- **Ingen hemsida:** hitta.se visar "Skapa en webbsida" (visas bara för firmor utan registrerad sajt)
+- **PROBLEM-vinkel:** "Måleri är ju ren före/efter, kunden väljer med ögonen. Men idag finns inte en
+  enda bild på era jobb när någon söker. Ni konkurrerar blint mot målare som visar sina."
+- **LÖSNING:** En sida med ett före/efter-galleri som säljer åt er, kunden är halvt övertygad innan
+  de ens ringer.
+
+## 5. Kärret Bygg — Sandsjöfors/Nässjö (kontakt: Jonny Johansson)
+- **Trade:** Byggservice & plattsättning, våtrumsbehörig
+- **Telefon:** 070-950 82... (avkortat i snippet — KOLLA hitta.se för fullständigt nr)
+- **Ingen hemsida:** bara kataloger, använder hotmail (hårt bevis)
+- **PROBLEM-vinkel:** "Hej Jonny. Ni är våtrumsbehöriga, det är precis det en kund vill kunna
+  kontrollera innan de bygger badrum för hundratusen. Men finns inget att hitta online kan de inte
+  verifiera er, och då ringer de nästa."
+- **LÖSNING:** En sida som visar behörigheten, jobben och garantierna svart på vitt, så att tryggheten
+  blir det första kunden ser.
+
+---
+
+## Den gemensamma kärnan (säg alltid)
+De har bevisat hantverket. De saknar bara skyltfönstret. En sida = en säljare som jobbar dygnet runt.
+Front offer: "Jag bygger ett gratis förslag på hur er sida kan se ut, du ser skillnaden och bestämmer
+sen. Låter det okej?" → JA-protokollet (kika på [plats] → "ser du samma sak?" → optionalitet).
+
+## Hitta fler själv på Google Maps (5 min, obegränsat)
+1. Maps → sök "byggfirma [din ort]" / "plattsättare" / "snickare" / "målare".
+2. Klicka varje träff. Har kortet INGEN "Webbplats"-knapp (bara Ring/Vägbeskrivning) = ingen hemsida.
+3. De med få/inga recensioner + ingen sajt = varmast. Spara namn + nummer, ring.


### PR DESCRIPTION
## Problemet

Alla demosidor fastnade på en svart laddskärm ("BRAND 0%") när man klickade på dem.

## Rotorsak (verifierad)

Sidan serveras korrekt av Vercel (HTTP 200), så det var inte routing eller deploy. Buggen satt i JavaScripten: **demosarna laddade GSAP från `cdn.jsdelivr.net`, medan startsidan använder `cdnjs.cloudflare.com`.** När jsdelivr inte når fram för besökaren (företagsnät, region, adblock, transient outage) blir `gsap` odefinierad → scriptet avbryts innan loadern göms → evig laddskärm. Det drabbade alla fem demos eftersom de delar samma CDN och mönster. Startsidan överlevde just för att dess GSAP kommer från cloudflare (som fungerar).

## Fix (alla 5 demos)

1. **GSAP + ScrollTrigger flyttade till `cdnjs.cloudflare.com`** — samma CDN som startsidan redan använder framgångsrikt.
2. **Lenis gjord valfri** — demon kör vidare med bara GSAP om Lenis-CDN:en skulle blockeras (smooth scroll är en bonus, inte ett krav).
3. **Felsäker loader** — `goStatic()` göms alltid efter 3,5 sekunder oavsett vad, plus en statisk `.fallback`-vy så sidan blir läsbar (hjältetext + sektioner synliga) istället för svart om något externt fallerar. Aldrig mer en evig laddskärm.

JS-syntax + CDN-byte verifierat på alla fem. Vercel-fetch bekräftade att sidan serveras 200.

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_