### PR TITLE
Add Asmar Relining scroll-cinematic demo

### DIFF
--- a/bahkobyra/cloud/asmar/index.html
+++ b/bahkobyra/cloud/asmar/index.html
@@ -1,0 +1,586 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
+<meta name="theme-color" content="#0A0E14">
+<meta name="description" content="Asmar Relining — nya rör utan stambyte. Relining, rörinspektion och spolning i Stockholm, Mälardalen och Uppsala. Demo av Bahko Byrå.">
+<title>Asmar Relining — Nya rör utan att riva</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://d8j0ntlcm91z4.cloudfront.net" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;500;600;700;800;900&family=Archivo+Expanded:wght@600;700;800;900&display=swap" rel="stylesheet">
+<style>
+*,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#0A0E14; --bg2:#0F1620; --card:#131C28;
+  --text:#EAF1F8; --muted:rgba(234,241,248,.62); --dim:rgba(234,241,248,.4);
+  --amber:#2E9BE6; --amber-lt:#6CC0F5; --amber-dk:#1A6CA8;
+  --line:rgba(234,241,248,.1);
+  --grad:linear-gradient(100deg,var(--amber-lt) 0%,var(--amber) 48%,#1A6CA8 100%);
+  --sans:'Archivo',system-ui,sans-serif; --disp:'Archivo Expanded','Archivo',sans-serif;
+  --ease:cubic-bezier(.22,1,.36,1);
+}
+html{background:var(--bg);scroll-behavior:auto}
+body{background:var(--bg);color:var(--text);font-family:var(--sans);overflow-x:hidden;-webkit-font-smoothing:antialiased;line-height:1.6}
+a{color:inherit;text-decoration:none}
+button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
+::selection{background:var(--amber);color:#04121C}
+.grad-text{background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+
+/* ===== LOADER ===== */
+#loader{position:fixed;inset:0;z-index:9999;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center;transition:opacity .6s ease,visibility .6s ease}
+#loader.hidden{opacity:0;visibility:hidden;pointer-events:none}
+.loader-brand{font-family:var(--disp);font-size:clamp(1.6rem,4.5vw,3rem);font-weight:900;letter-spacing:.25em;margin-bottom:3rem;text-transform:uppercase}
+.loader-brand em{font-style:normal;color:var(--amber)}
+#loader-bar-wrap{width:min(300px,60vw);height:1px;background:rgba(46,155,230,.2);overflow:hidden}
+#loader-bar{width:0%;height:100%;background:var(--grad);transition:width .3s ease}
+#loader-percent{font-size:.72rem;letter-spacing:.25em;color:var(--dim);margin-top:1.2rem;font-weight:400}
+
+/* ===== HEADER ===== */
+.site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1.6rem,env(safe-area-inset-top)) clamp(1.2rem,4vw,3rem) 1.6rem;display:flex;justify-content:space-between;align-items:center;transition:background .4s,border-color .4s;border-bottom:1px solid transparent}
+.site-header.scrolled{background:rgba(10,14,20,.82);backdrop-filter:blur(18px) saturate(1.2);-webkit-backdrop-filter:blur(18px) saturate(1.2);border-bottom-color:var(--line)}
+.header-logo{font-family:var(--disp);font-weight:900;font-size:1.05rem;letter-spacing:.18em;text-transform:uppercase}
+.header-logo em{font-style:normal;color:var(--amber)}
+.header-nav{display:flex;gap:2.4rem;align-items:center}
+.header-nav a{position:relative;font-size:.68rem;font-weight:600;letter-spacing:.2em;text-transform:uppercase;opacity:.75;transition:opacity .3s,color .3s}
+.header-nav a::after{content:'';position:absolute;left:0;bottom:-5px;height:1px;width:0;background:var(--amber);transition:width .35s var(--ease)}
+.header-nav a:hover{opacity:1;color:var(--amber-lt)}
+.header-nav a:hover::after{width:100%}
+.header-nav .nav-cta{opacity:1;background:var(--grad);color:#04121C;padding:.68rem 1.4rem;border-radius:4px;font-weight:700;box-shadow:0 10px 28px -12px rgba(46,155,230,.55);transition:transform .2s,box-shadow .3s}
+.header-nav .nav-cta::after{display:none}
+.header-nav .nav-cta:hover{transform:translateY(-2px);color:#04121C;box-shadow:0 16px 36px -12px rgba(46,155,230,.7)}
+
+/* Hamburger + mobilnav */
+.hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:10px;margin:-10px;z-index:200}
+.hamburger span{display:block;width:22px;height:1.5px;background:var(--text);transition:all .3s ease}
+.hamburger.open span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger.open span:nth-child(2){opacity:0}
+.hamburger.open span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-nav{position:fixed;inset:0;background:rgba(10,14,20,.96);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;opacity:0;visibility:hidden;transition:all .4s ease}
+.mobile-nav.open{opacity:1;visibility:visible}
+.mobile-nav a{font-family:var(--disp);font-size:2rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase;opacity:.8;transition:opacity .3s,color .3s}
+.mobile-nav a:hover{opacity:1;color:var(--amber)}
+
+/* ===== HERO (förvandlingsvideon loopar som gif) ===== */
+.hero-standalone{position:relative;width:100%;height:100svh;display:flex;align-items:center;justify-content:center;overflow:hidden;z-index:10}
+.hero-vid-wrap{position:absolute;inset:0}
+.hero-vid-wrap video{width:100%;height:100%;object-fit:cover}
+.hero-vid-wrap::after{content:'';position:absolute;inset:0;background:
+  linear-gradient(180deg,rgba(10,14,20,.6) 0%,rgba(10,14,20,.25) 38%,rgba(10,14,20,.35) 68%,rgba(10,14,20,.92) 100%)}
+.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(5rem,12vh,8rem)}
+.hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
+.hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
+.hero-heading .word{display:inline-block;opacity:0;transform:translateY(60px)}
+.hero-heading .accent{background:var(--grad);background-size:220% auto;-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;animation:shimmer 7s linear infinite}
+@keyframes shimmer{to{background-position:220% center}}
+.hero-tagline{font-size:clamp(.74rem,1.1vw,.95rem);font-weight:400;letter-spacing:.18em;color:var(--muted);text-transform:uppercase;opacity:0}
+.hero-scroll-indicator{position:absolute;bottom:2.6rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0;z-index:2}
+.hero-scroll-indicator span{font-size:.58rem;letter-spacing:.32em;color:var(--dim);text-transform:uppercase}
+.scroll-arrow{width:1px;height:42px;position:relative;overflow:hidden}
+.scroll-arrow::after{content:'';position:absolute;top:-100%;left:0;width:1px;height:100%;background:var(--amber);animation:scrollDown 2.1s var(--ease) infinite}
+@keyframes scrollDown{0%{top:-100%}50%{top:0}100%{top:100%}}
+
+/* ===== FAST VIDEOLAGER (steget in-loopen bakom scroll-sektionerna) ===== */
+.bgvid-wrap{position:fixed;top:0;left:0;width:100%;height:100%;z-index:1;clip-path:circle(0% at 50% 50%);will-change:clip-path}
+.bgvid-wrap video{width:100%;height:100%;object-fit:cover;filter:brightness(.62)}
+.bgvid-wrap::after{content:'';position:absolute;inset:0;background:
+  radial-gradient(120% 90% at 50% 50%,transparent 0%,rgba(10,14,20,.66) 100%),
+  linear-gradient(180deg,rgba(10,14,20,.45) 0%,transparent 30%,transparent 70%,rgba(10,14,20,.5) 100%)}
+
+/* ===== DARK OVERLAY ===== */
+#dark-overlay{position:fixed;inset:0;background:var(--bg);opacity:0;z-index:3;pointer-events:none;will-change:opacity}
+
+/* ===== SCROLL CONTAINER ===== */
+#scroll-container{position:relative;width:100%;height:700vh;z-index:5}
+
+/* ===== SEKTIONER ===== */
+.scroll-section{position:absolute;width:100%;display:flex;align-items:center;opacity:0;visibility:hidden;will-change:transform,opacity}
+.scroll-section.active{opacity:1;visibility:visible}
+.align-left{padding-left:6vw;padding-right:50vw}
+.align-right{padding-left:50vw;padding-right:6vw}
+.align-left .section-inner,.align-right .section-inner{max-width:42vw}
+.section-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.4em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:1.2rem}
+.section-heading{font-family:var(--disp);font-size:clamp(1.9rem,4.6vw,4.4rem);font-weight:900;line-height:1.04;text-transform:uppercase;letter-spacing:-.01em;margin-bottom:1.2rem;text-shadow:0 4px 30px rgba(0,0,0,.5)}
+.section-body{font-size:clamp(.86rem,1vw,1rem);font-weight:400;line-height:1.8;color:var(--muted);max-width:480px}
+.section-note{font-size:clamp(.92rem,1.15vw,1.1rem);color:var(--amber-lt);margin-top:1.2rem;font-weight:500;font-style:italic}
+
+/* ===== PROJEKT ===== */
+.section-projects{justify-content:center;padding:0 5vw}
+.projects-inner{width:min(1240px,92vw)}
+.projects-head{text-align:center;margin-bottom:2.2rem}
+.projects-head .section-heading{margin-bottom:.4rem}
+.projects-head p{color:var(--dim);font-size:.84rem}
+.work-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.1rem}
+.wcard{position:relative;border-radius:8px;overflow:hidden;background:var(--card);aspect-ratio:4/4.4;border:1px solid var(--line)}
+.wcard img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform 1.1s var(--ease)}
+.wcard:hover img{transform:scale(1.06)}
+.wcard::after{content:'';position:absolute;inset:0;background:linear-gradient(180deg,transparent 38%,rgba(10,14,20,.94) 100%)}
+.wc-body{position:absolute;left:1.3rem;right:1.3rem;bottom:1.2rem;z-index:2}
+.wc-tag{font-size:.56rem;font-weight:700;letter-spacing:.22em;text-transform:uppercase;color:var(--amber-lt)}
+.wc-body h3{font-family:var(--disp);font-weight:800;font-size:1.25rem;margin:.3rem 0 .2rem}
+.wc-body p{font-size:.76rem;color:var(--muted)}
+
+/* ===== TJÄNSTER ===== */
+.services-list{display:flex;flex-direction:column;gap:1.6rem}
+.service-item{display:flex;align-items:baseline;gap:1rem;padding-bottom:1.1rem;border-bottom:1px solid rgba(46,155,230,.16)}
+.service-name{font-family:var(--disp);font-size:clamp(1.05rem,1.7vw,1.5rem);font-weight:800;flex:1}
+.service-tag{font-size:.7rem;letter-spacing:.16em;color:var(--amber-lt);font-weight:600;text-transform:uppercase}
+.service-time{font-size:.68rem;color:var(--dim)}
+
+/* ===== STATS ===== */
+.section-stats{justify-content:center;text-align:center;padding:0 5vw}
+.stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(1.5rem,4vw,4rem);max-width:920px;width:100%}
+.stat{display:flex;flex-direction:column;align-items:center;gap:.3rem}
+.stat-number{font-family:var(--disp);font-size:clamp(2.3rem,5vw,4.8rem);font-weight:900;line-height:1}
+.stat-suffix{font-family:var(--disp);font-size:clamp(1.1rem,2vw,1.9rem);font-weight:800;color:var(--amber);margin-left:.08em;display:inline}
+.stat-label{font-size:.58rem;letter-spacing:.26em;text-transform:uppercase;color:var(--dim);margin-top:.35rem}
+
+/* ===== CTA ===== */
+.section-cta{justify-content:center;text-align:center;padding:0 5vw}
+.cta-inner{display:flex;flex-direction:column;align-items:center;gap:1.4rem}
+.cta-button{position:relative;overflow:hidden;display:inline-flex;align-items:center;gap:.8rem;font-size:.74rem;font-weight:800;letter-spacing:.2em;text-transform:uppercase;color:#04121C;background:var(--grad);padding:1.15rem 2.8rem;border-radius:4px;box-shadow:0 18px 50px -18px rgba(46,155,230,.6);transition:box-shadow .35s,transform .25s}
+.cta-button::before{content:'';position:absolute;inset:0;background:var(--amber-lt);transform:scaleX(0);transform-origin:0 50%;transition:transform .45s var(--ease);z-index:0}
+.cta-button:hover::before{transform:scaleX(1)}
+.cta-button:hover{box-shadow:0 24px 60px -18px rgba(46,155,230,.8);transform:translateY(-2px)}
+.cta-button span,.cta-button svg{position:relative;z-index:1}
+.cta-button svg{width:15px;height:15px;stroke:currentColor;stroke-width:2.4;fill:none;transition:transform .35s var(--ease)}
+.cta-button:hover svg{transform:translateX(4px)}
+.cta-sub{font-size:.6rem;letter-spacing:.24em;color:var(--dim);text-transform:uppercase}
+
+/* ===== FLYTANDE OFFERT-KNAPP ===== */
+#float-offert{position:fixed;bottom:max(2.4rem,env(safe-area-inset-bottom));right:2.4rem;z-index:90;background:var(--grad);color:#04121C;font-size:.64rem;font-weight:800;letter-spacing:.22em;text-transform:uppercase;padding:.85rem 1.7rem;border-radius:4px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 10px 30px -8px rgba(46,155,230,.5)}
+#float-offert.visible{opacity:1;transform:translateY(0);pointer-events:auto}
+#float-offert:hover{box-shadow:0 16px 40px -8px rgba(46,155,230,.7);transform:translateY(-2px) scale(1.03)}
+
+/* ===== FOOTER ===== */
+footer{position:relative;z-index:6;border-top:1px solid var(--line);padding:1.8rem clamp(1.2rem,4vw,3rem);display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap;font-size:.7rem;color:var(--dim);background:var(--bg)}
+footer a{color:var(--amber-lt)}
+
+/* ===== MODAL (Bahko demo) ===== */
+.modal-bg{position:fixed;inset:0;z-index:500;background:rgba(10,14,20,.72);backdrop-filter:blur(10px);display:grid;place-items:center;padding:1.2rem;opacity:0;visibility:hidden;transition:.35s}
+.modal-bg.open{opacity:1;visibility:visible}
+.modal{background:var(--bg2);border:1px solid rgba(46,155,230,.3);border-radius:12px;max-width:480px;width:100%;padding:2.6rem;position:relative;box-shadow:0 40px 110px rgba(0,0,0,.6)}
+.modal-x{position:absolute;top:1rem;right:1.2rem;font-size:1.3rem;color:var(--dim);padding:.4rem}
+.modal-x:hover{color:var(--text)}
+.m-badge{display:inline-block;font-size:.58rem;letter-spacing:.24em;text-transform:uppercase;color:var(--amber-lt);background:rgba(46,155,230,.1);border:1px solid rgba(46,155,230,.25);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.3rem}
+.modal h3{font-family:var(--disp);font-weight:800;font-size:1.7rem;line-height:1.15;margin-bottom:.6rem}
+.modal p{font-size:.88rem;color:var(--muted);margin-bottom:1.6rem}
+.modal .cta-button{width:100%;justify-content:center;font-size:.72rem;padding:1rem 1.4rem}
+.m-alt{display:block;text-align:center;font-size:.74rem;color:var(--dim);margin-top:1rem;transition:color .3s}
+.m-alt:hover{color:var(--amber-lt)}
+.m-foot{margin-top:1.6rem;padding-top:1.1rem;border-top:1px solid var(--line);text-align:center;font-size:.62rem;letter-spacing:.16em;color:var(--dim)}
+.m-foot a{color:var(--amber-lt);font-weight:600}
+
+/* ===== MOBIL ===== */
+@media(max-width:768px){
+  .header-nav{display:none}
+  .hamburger{display:flex}
+  .align-left,.align-right{padding-left:6vw;padding-right:6vw}
+  .align-left .section-inner,.align-right .section-inner{max-width:100%}
+  .scroll-section .section-inner{background:rgba(10,14,20,.74);backdrop-filter:blur(8px);padding:1.8rem;border-radius:8px;border:1px solid var(--line)}
+  #scroll-container{height:500vh}
+  .work-grid{grid-template-columns:1fr;gap:.9rem}
+  .wcard{aspect-ratio:4/2.8}
+  .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.8rem}
+  .hero-heading{font-size:clamp(2.3rem,11vw,5rem)}
+  .cta-button{padding:.95rem 2rem;width:100%;justify-content:center}
+  #float-offert{bottom:max(1.4rem,env(safe-area-inset-bottom));right:1.4rem;font-size:.58rem;padding:.72rem 1.3rem}
+  .modal{padding:1.8rem 1.4rem}
+  .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
+}
+html.fallback #loader{display:none}
+html.fallback #scroll-container{height:auto}
+html.fallback .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll-indicator{opacity:1!important}
+html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
+@media(prefers-reduced-motion:reduce){
+  *{animation:none!important;transition:none!important}
+  #loader{display:none}
+  #scroll-container{height:auto}
+  .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
+  .hero-label,.hero-tagline,.hero-scroll-indicator{opacity:1!important}
+  .hero-heading .word{opacity:1!important;transform:none!important}
+  .bgvid-wrap{display:none}
+}
+</style>
+</head>
+<body>
+
+<!-- LOADER -->
+<div id="loader">
+  <div class="loader-brand">ASMAR<em>.</em></div>
+  <div id="loader-bar-wrap"><div id="loader-bar"></div></div>
+  <div id="loader-percent">0%</div>
+</div>
+
+<!-- MOBILNAV -->
+<nav class="mobile-nav" id="mobile-nav">
+  <a href="#" onclick="closeMobileNav()">Metoden</a>
+  <a href="#" onclick="closeMobileNav()">Tjänster</a>
+  <a href="#" onclick="closeMobileNav()">Referenser</a>
+  <a href="#" onclick="openModal();closeMobileNav()">Boka inspektion</a>
+</nav>
+
+<!-- HEADER -->
+<header class="site-header" id="site-header">
+  <a href="#" class="header-logo">ASMAR <em>RELINING</em></a>
+  <nav class="header-nav">
+    <a href="#">Metoden</a>
+    <a href="#">Tjänster</a>
+    <a href="#">Referenser</a>
+    <a href="#" class="nav-cta" onclick="openModal();return false">Boka inspektion</a>
+  </nav>
+  <button class="hamburger" id="hamburger" onclick="toggleMobileNav()" aria-label="Meny">
+    <span></span><span></span><span></span>
+  </button>
+</header>
+
+<!-- HERO — förvandlingsvideon loopar som gif -->
+<section class="hero-standalone">
+  <div class="hero-vid-wrap">
+    <video id="hero-vid" autoplay muted loop playsinline preload="auto"
+      poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_145746_69c936ae-a988-4beb-a11a-96d36da595e2.png"
+      src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_150203_9b2cfe7b-268b-42a2-8afa-22bfe225018e.mp4"></video>
+  </div>
+  <div class="hero-content">
+    <span class="hero-label">Relining &amp; Rörinspektion · Stockholm · Mälardalen · Uppsala</span>
+    <h1 class="hero-heading">
+      <span class="word">Nya rör.</span><br>
+      <span class="word accent">Utan att riva.</span>
+    </h1>
+    <p class="hero-tagline">Utan stambyte · Bo kvar under tiden · 10 års garanti</p>
+  </div>
+  <div class="hero-scroll-indicator">
+    <span>Se förvandlingen</span>
+    <div class="scroll-arrow"></div>
+  </div>
+</section>
+
+<!-- FAST VIDEOLAGER — steget in-loopen bakom sektionerna -->
+<div class="bgvid-wrap" id="bgvid-wrap">
+  <video id="bg-vid" autoplay muted loop playsinline preload="metadata"
+    poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_145834_a5413221-786f-4a07-8f0f-1a84a22b0ccd.png"
+    src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_150220_b6914645-6db5-41f4-b26c-8e290b70b7fc.mp4"></video>
+</div>
+<div id="dark-overlay"></div>
+
+<!-- SCROLL CONTAINER -->
+<div id="scroll-container">
+
+  <section class="scroll-section align-left" data-enter="8" data-leave="22" data-animation="slide-left">
+    <div class="section-inner">
+      <span class="section-label">001 / Metoden</span>
+      <h2 class="section-heading">Vi river inte.<br>Vi förnyar.</h2>
+      <p class="section-body">Ett stambyte betyder uppbilade golv, månader av kaos och en flytt under tiden. Relining gör samma jobb inifrån: vi förnyar röret med ett nytt sömlöst skikt, ni bor kvar, och det är klart på dagar istället för månader. Samma trygghet, en bråkdel av besväret.</p>
+      <p class="section-note">"Andra ser ett rivningsjobb. Vi ser ett rör som kan förnyas inifrån."</p>
+    </div>
+  </section>
+
+  <section class="scroll-section section-projects" data-enter="26" data-leave="42" data-animation="stagger-up">
+    <div class="projects-inner">
+      <div class="projects-head">
+        <span class="section-label">002 / Referenser</span>
+        <h2 class="section-heading">Bevis i röret.<br><span class="grad-text">Inte löften.</span></h2>
+        <p>Vi filmar före och efter. Du ser skillnaden med egna ögon.</p>
+      </div>
+      <div class="work-grid">
+        <article class="wcard">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_145834_a5413221-786f-4a07-8f0f-1a84a22b0ccd.png" alt="Nyrelinad stam, blank insida" loading="lazy">
+          <div class="wc-body">
+            <div class="wc-tag">Stamrenovering BRF</div>
+            <h3>BRF i Vasastan</h3>
+            <p>Stammar förnyade med relining — boende kvar hela tiden, inget stambyte.</p>
+          </div>
+        </article>
+        <article class="wcard">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_150023_37a3e37b-075c-4365-836e-58e6e32fce79.png" alt="Rörinspektion med kamera" loading="lazy">
+          <div class="wc-body">
+            <div class="wc-tag">Rörinspektion</div>
+            <h3>Filmning &amp; spolning</h3>
+            <p>Vi filmar röret och visar exakt vad som behöver göras innan vi börjar.</p>
+          </div>
+        </article>
+        <article class="wcard">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_150024_0298aa3c-b7bb-4dba-8a28-ad2cc55fb304.png" alt="Renoverat badrum" loading="lazy">
+          <div class="wc-body">
+            <div class="wc-tag">Relining villa</div>
+            <h3>Villa i Täby</h3>
+            <p>Avloppet förnyat inifrån på två dagar — inget uppbilat golv.</p>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section align-right" data-enter="46" data-leave="60" data-animation="slide-right">
+    <div class="section-inner">
+      <span class="section-label">003 / Tjänster</span>
+      <h2 class="section-heading">Rätt metod.<br>Rätt rör.</h2>
+      <div class="services-list">
+        <div class="service-item">
+          <span class="service-name">Relining</span>
+          <span class="service-tag">Utan stambyte</span>
+          <span class="service-time">Bo kvar</span>
+        </div>
+        <div class="service-item">
+          <span class="service-name">Rörinspektion &amp; filmning</span>
+          <span class="service-tag">Kostnadsfritt</span>
+          <span class="service-time">Avlopp &amp; stammar</span>
+        </div>
+        <div class="service-item">
+          <span class="service-name">Spolning &amp; rotskärning</span>
+          <span class="service-tag">Akut &amp; underhåll</span>
+          <span class="service-time">Hela Storstockholm</span>
+        </div>
+        <div class="service-item">
+          <span class="service-name">Stamrenovering BRF</span>
+          <span class="service-tag">Helhetsansvar</span>
+          <span class="service-time">Plan till klart</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section section-stats" data-enter="64" data-leave="78" data-animation="stagger-up">
+    <div class="stats-grid">
+      <div class="stat">
+        <div><span class="stat-number" data-value="10" data-decimals="0">0</span><span class="stat-suffix">+</span></div>
+        <span class="stat-label">År i branschen</span>
+      </div>
+      <div class="stat">
+        <div><span class="stat-number" data-value="50" data-decimals="0">0</span><span class="stat-suffix">%</span></div>
+        <span class="stat-label">Billigare än stambyte</span>
+      </div>
+      <div class="stat">
+        <div><span class="stat-number" data-value="10" data-decimals="0">0</span><span class="stat-suffix"> år</span></div>
+        <span class="stat-label">Garanti på relining</span>
+      </div>
+      <div class="stat">
+        <div><span class="stat-number" data-value="0" data-decimals="0">0</span><span class="stat-suffix"> rivet</span></div>
+        <span class="stat-label">Bo kvar under tiden</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="scroll-section section-cta" data-enter="84" data-leave="100" data-animation="scale-up" data-persist="true">
+    <div class="cta-inner">
+      <span class="section-label">Nästa steg</span>
+      <h2 class="section-heading" style="font-size:clamp(2.4rem,6.5vw,6rem)">Hur ser det ut<br><span class="grad-text">i era rör?</span></h2>
+      <button class="cta-button" onclick="openModal()">
+        <span>Boka gratis rörinspektion</span>
+        <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </button>
+      <span class="cta-sub">Utan stambyte · Bo kvar · Svar inom 24h</span>
+    </div>
+  </section>
+
+</div>
+
+<!-- FLYTANDE OFFERT-KNAPP -->
+<button id="float-offert" onclick="openModal()">Boka inspektion</button>
+
+<footer>
+  <span>Asmar Relining · Demo</span>
+  <span>Byggd av <a href="https://bahkobyra.se" target="_blank" rel="noopener">Bahko Byrå</a></span>
+</footer>
+
+<!-- BAHKO DEMO-MODAL -->
+<div class="modal-bg" id="modal">
+  <div class="modal">
+    <button class="modal-x" onclick="closeModal()" aria-label="Stäng">✕</button>
+    <div class="m-badge">Demo av Bahko Byrå</div>
+    <h3>Vill du ha en sida som denna för ditt VVS-företag?</h3>
+    <p>Ni får redan trafiken. Boka ett kostnadsfritt 15-minuterssamtal med Mathias, så visar vi hur sidan kan få fler av besökarna att faktiskt boka en inspektion.</p>
+    <button class="cta-button" data-cal-namespace="15min" data-cal-link="bahkobyra/15min" data-cal-origin="https://cal.eu"><span>Boka 15 min gratis samtal →</span></button>
+    <a class="m-alt" href="mailto:mathias@bahkobyra.se?subject=Intresserad av demo-hemsida (relining)&body=Hej Mathias, jag såg Asmar-demon och vill veta mer.">Eller mejla → mathias@bahkobyra.se</a>
+    <div class="m-foot"><a href="https://bahkobyra.se" target="_blank" rel="noopener">Bahko Byrå</a> · Synlighet som säljer.</div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js"></script>
+<script>
+(function(){
+  "use strict";
+  const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const htmlEl=document.documentElement, loaderEl=document.getElementById('loader');
+  function goStatic(){htmlEl.classList.add('fallback');if(loaderEl)loaderEl.classList.add('hidden');if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});}
+  const failsafe=setTimeout(goStatic,3500);
+
+  // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
+  function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
+  addEventListener('touchstart',kickVideos,{once:true,passive:true});
+  addEventListener('pointerdown',kickVideos,{once:true,passive:true});
+
+  if(reduce){
+    document.querySelectorAll('video').forEach(v=>{v.autoplay=false;v.pause();});
+    clearTimeout(failsafe);goStatic();
+    return;
+  }
+  if(typeof gsap==='undefined'){clearTimeout(failsafe);goStatic();return;}
+  gsap.registerPlugin(ScrollTrigger);
+
+  // ===== LENIS (valfri — demon funkar utan smooth scroll om CDN:en blockeras) =====
+  if(typeof Lenis!=='undefined'){
+    const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+    lenis.on('scroll',ScrollTrigger.update);
+    gsap.ticker.add(t=>lenis.raf(t*1000));
+    gsap.ticker.lagSmoothing(0);
+  }
+
+  // ===== LOADER =====
+  const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
+  let loadProg=0;
+  (function simulateLoad(){
+    loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
+    loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
+    if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+  })();
+
+  // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====
+  function animateHero(){
+    gsap.timeline()
+      .to('.hero-label',{opacity:1,duration:.8,ease:'power2.out'},0.2)
+      .to('.hero-heading .word',{opacity:1,y:0,stagger:.15,duration:1.05,ease:'power3.out'},0.4)
+      .to('.hero-tagline',{opacity:1,duration:.8,ease:'power2.out'},1.05)
+      .to('.hero-scroll-indicator',{opacity:1,duration:.8,ease:'power2.out'},1.35);
+  }
+
+  // ===== CIRKELAVTÄCKNING: videolagret avtäcks MEDAN heron scrollar ut =====
+  const scrollContainer=document.getElementById('scroll-container');
+  const heroSection=document.querySelector('.hero-standalone');
+  const bgWrap=document.getElementById('bgvid-wrap');
+
+  ScrollTrigger.create({
+    trigger:heroSection,start:'top top',end:'bottom top',scrub:true,
+    onUpdate:self=>{
+      const p=self.progress;
+      bgWrap.style.clipPath=`circle(${Math.min(1,p*1.35)*75}% at 50% 50%)`;
+    }
+  });
+
+  // ===== SEKTIONER (absolut positionerade på progress-fönster, olika entréer) =====
+  const sections=document.querySelectorAll('.scroll-section');
+  function placeSections(){
+    sections.forEach(s=>{
+      const e=parseFloat(s.dataset.enter)/100,l=parseFloat(s.dataset.leave)/100,m=(e+l)/2;
+      s.style.top=(m*scrollContainer.offsetHeight)+'px'; s.style.transform='translateY(-50%)';
+    });
+  }
+  placeSections();
+
+  const sectionStates=new Map();
+  sections.forEach(section=>{
+    const type=section.dataset.animation,persist=section.dataset.persist==='true';
+    const enter=parseFloat(section.dataset.enter)/100,leave=parseFloat(section.dataset.leave)/100,fadeRange=0.03;
+    const children=section.querySelectorAll('.section-label,.section-heading,.section-body,.section-note,.cta-button,.cta-sub,.stat,.service-item,.wcard,.projects-head');
+    const tl=gsap.timeline({paused:true});
+    switch(type){
+      case 'fade-up': tl.from(children,{y:50,opacity:0,stagger:.12,duration:.9,ease:'power3.out'}); break;
+      case 'slide-left': tl.from(children,{x:-80,opacity:0,stagger:.14,duration:.9,ease:'power3.out'}); break;
+      case 'slide-right': tl.from(children,{x:80,opacity:0,stagger:.14,duration:.9,ease:'power3.out'}); break;
+      case 'scale-up': tl.from(children,{scale:.85,opacity:0,stagger:.12,duration:1.0,ease:'power2.out'}); break;
+      case 'stagger-up': tl.from(children,{y:60,opacity:0,stagger:.13,duration:.85,ease:'power3.out'}); break;
+      case 'clip-reveal': tl.from(children,{clipPath:'inset(100% 0 0 0)',opacity:0,stagger:.15,duration:1.2,ease:'power4.inOut'}); break;
+    }
+    sectionStates.set(section,{tl,persist,enter,leave,fadeRange,active:false,persisted:false});
+  });
+
+  ScrollTrigger.create({
+    trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+    onUpdate:self=>{
+      const p=self.progress;
+      sectionStates.forEach((state,section)=>{
+        const{tl,persist,enter,leave,fadeRange}=state;
+        const shouldShow=p>=(enter-fadeRange)&&(persist?true:p<=(leave+fadeRange));
+        if(shouldShow&&!state.active){section.classList.add('active');section.style.visibility='visible';tl.play();state.active=true;}
+        else if(!shouldShow&&state.active&&!state.persisted){tl.reverse();state.active=false;}
+        if(persist&&state.active)state.persisted=true;
+        if(state.active||state.persisted){
+          let o=1;
+          if(p<enter)o=Math.max(0,(p-(enter-fadeRange))/fadeRange);
+          else if(!persist&&p>leave)o=Math.max(0,1-(p-leave)/fadeRange);
+          section.style.opacity=o;
+        } else {
+          section.style.opacity=0;
+        }
+      });
+    }
+  });
+
+  // ===== RÄKNARE =====
+  const animated=new Set();
+  document.querySelectorAll('.stat-number').forEach(el=>{
+    const target=parseFloat(el.dataset.value),decimals=parseInt(el.dataset.decimals||'0');
+    ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',
+      onUpdate:self=>{
+        const p=self.progress;
+        if(p>=0.64&&p<=0.78&&!animated.has(el)){
+          animated.add(el);
+          gsap.to({val:0},{val:target,duration:2,ease:'power1.out',onUpdate:function(){el.textContent=this.targets()[0].val.toFixed(decimals);}});
+        } else if(p<0.60&&animated.has(el)){animated.delete(el);el.textContent='0';}
+      }
+    });
+  });
+
+  // ===== DARK OVERLAY (två fönster: projekt + stats) =====
+  (function(){
+    const overlay=document.getElementById('dark-overlay');
+    const windows=[{e:0.25,l:0.43,max:0.5},{e:0.63,l:0.79,max:0.55}];
+    const fr=0.035;
+    ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
+      onUpdate:self=>{
+        const p=self.progress;
+        let o=0;
+        windows.forEach(({e,l,max})=>{
+          if(p>=e-fr&&p<=e)o=Math.max(o,((p-(e-fr))/fr)*max);
+          else if(p>e&&p<l)o=Math.max(o,max);
+          else if(p>=l&&p<=l+fr)o=Math.max(o,max*(1-(p-l)/fr));
+        });
+        overlay.style.opacity=o;
+      }
+    });
+  })();
+
+  // ===== HEADER + FLYTKNAPP =====
+  addEventListener('scroll',()=>{
+    document.getElementById('site-header').classList.toggle('scrolled',scrollY>80);
+    document.getElementById('float-offert').classList.toggle('visible',scrollY>innerHeight*.6);
+  },{passive:true});
+
+  // ===== RESIZE =====
+  addEventListener('resize',()=>{placeSections();ScrollTrigger.refresh();});
+
+  setTimeout(()=>ScrollTrigger.refresh(),400);
+})();
+
+// ===== MODAL =====
+function openModal(){document.getElementById('modal').classList.add('open');document.body.style.overflow='hidden';}
+function closeModal(){document.getElementById('modal').classList.remove('open');document.body.style.overflow='';}
+document.getElementById('modal').addEventListener('click',function(e){if(e.target===this)closeModal();});
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeModal();});
+
+// ===== MOBILNAV =====
+function toggleMobileNav(){
+  const nav=document.getElementById('mobile-nav'),btn=document.getElementById('hamburger');
+  nav.classList.toggle('open');btn.classList.toggle('open');
+  document.body.style.overflow=nav.classList.contains('open')?'hidden':'';
+}
+function closeMobileNav(){
+  document.getElementById('mobile-nav').classList.remove('open');
+  document.getElementById('hamburger').classList.remove('open');
+  document.body.style.overflow='';
+}
+</script>
+<!-- Cal.eu embed -->
+<script type="text/javascript">
+(function(C,A,L){let p=function(a,ar){a.q.push(ar)};let d=C.document;C.Cal=C.Cal||function(){let cal=C.Cal;let ar=arguments;if(!cal.loaded){cal.ns={};cal.q=cal.q||[];d.head.appendChild(d.createElement("script")).src=A;cal.loaded=true}if(ar[0]===L){const api=function(){p(api,arguments)};const namespace=ar[1];api.q=api.q||[];if(typeof namespace==="string"){cal.ns[namespace]=cal.ns[namespace]||api;p(cal.ns[namespace],ar);p(cal,[L,namespace,...Array.from(ar).slice(2)])}else p(cal,ar);return}p(cal,ar)};})(window,"https://cal.eu/embed/embed.js","init");
+Cal("init","15min",{origin:"https://cal.eu"});
+Cal.ns["15min"]("ui",{"hideEventTypeDetails":false,"layout":"month_view"});
+</script>
+</body>
+</html>

--- a/bahkobyra/cloud/asmar/index.html
+++ b/bahkobyra/cloud/asmar/index.html
@@ -287,7 +287,7 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
       </div>
       <div class="work-grid">
         <article class="wcard">
-          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_145834_a5413221-786f-4a07-8f0f-1a84a22b0ccd.png" alt="Nyrelinad stam, blank insida" loading="lazy">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260617_150658_5b5d9b18-2c23-484f-8814-0607f0d76b90.jpeg" alt="Flerbostadshus i Stockholm" loading="lazy">
           <div class="wc-body">
             <div class="wc-tag">Stamrenovering BRF</div>
             <h3>BRF i Vasastan</h3>


### PR DESCRIPTION
Relining-anpassad GRANIT/Élara-demo för Instagram-leadet **asmar_relining** (relining/VVS, Stockholm/Mälardalen/Uppsala).

## Konceptet
Förvandlingen visar **det osynliga rörjobbet** (proof-vinkeln):
- **Hero-loop:** korroderat gammalt rör (inspektionskamera-vy) → blankt nyrelinat rör
- **Bakgrundsloop:** kameran glider ut ur det relinade röret in i ett rent badrum

Båda Higgsfield-genererade (nano_banana_pro keyframes + seedance_2_0 video), autoplay-loopar som gif.

## Anpassningar mot mallen
- Blå "vatten/trygghet"-palett istället för amber
- Copy byggd på säljvinkeln **"fler kundförfrågningar på trafiken de redan har"** (de ligger etta på Google + har bra sida): bevis i röret, "boka gratis rörinspektion", trygghet för BRF
- Tre referenskort: nyrelinad stam (BRF), rörinspektion, renoverat badrum
- `noindex, nofollow` + Bahko-modal (Cal.eu `bahkobyra/15min`)

Live efter merge: `bahkobyra.se/cloud/asmar/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_