### PR TITLE
Matstugan: fixa hero-textöverlapp på breda/låga fönster

### DIFF
--- a/bahkobyra/cloud/pizzeriamatstugan/index.html
+++ b/bahkobyra/cloud/pizzeriamatstugan/index.html
@@ -69,7 +69,7 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .hero-vid-wrap video{width:100%;height:100%;object-fit:cover}
 .hero-vid-wrap::after{content:'';position:absolute;inset:0;background:
   linear-gradient(180deg,rgba(11,11,13,.6) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
-.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(5rem,12vh,8rem)}
+.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(7rem,15vh,10rem)}
 .hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
 .hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
 .hero-heading .word{display:inline-block;opacity:0;transform:translateY(26px)}
@@ -77,7 +77,7 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 @keyframes shimmer{to{background-position:220% center}}
 .hero-tagline{font-size:clamp(.74rem,1.1vw,.95rem);font-weight:400;letter-spacing:.18em;color:var(--muted);text-transform:uppercase;opacity:0}
 .hero-book-btn{font-size:.66rem;padding:.85rem 2rem}
-.hero-scroll-indicator{position:absolute;bottom:2.6rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0;z-index:2}
+.hero-scroll-indicator{position:absolute;bottom:1.3rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0;z-index:2}
 .hero-scroll-indicator span{font-size:.58rem;letter-spacing:.32em;color:var(--dim);text-transform:uppercase}
 .scroll-arrow{width:1px;height:42px;position:relative;overflow:hidden}
 .scroll-arrow::after{content:'';position:absolute;top:-100%;left:0;width:1px;height:100%;background:var(--amber);animation:scrollDown 2.1s var(--ease) infinite}

--- a/bahkobyra/cloud/pizzeriamatstugan/index.html
+++ b/bahkobyra/cloud/pizzeriamatstugan/index.html
@@ -69,7 +69,7 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .hero-vid-wrap video{width:100%;height:100%;object-fit:cover}
 .hero-vid-wrap::after{content:'';position:absolute;inset:0;background:
   linear-gradient(180deg,rgba(11,11,13,.6) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
-.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(7rem,15vh,10rem)}
+.hero-content{position:relative;z-index:2;text-align:center;padding:clamp(5rem,11vh,7rem) 5vw clamp(7rem,15vh,10rem)}
 .hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
 .hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
 .hero-heading .word{display:inline-block;opacity:0;transform:translateY(26px)}
@@ -82,6 +82,15 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .scroll-arrow{width:1px;height:42px;position:relative;overflow:hidden}
 .scroll-arrow::after{content:'';position:absolute;top:-100%;left:0;width:1px;height:100%;background:var(--amber);animation:scrollDown 2.1s var(--ease) infinite}
 @keyframes scrollDown{0%{top:-100%}50%{top:0}100%{top:100%}}
+/* Breda men låga fönster: krymp rubriken så label/tagline/knapp aldrig överlappar */
+@media(min-width:769px) and (max-height:880px){
+  .hero-heading{font-size:clamp(2.4rem,7.4vw,6.6rem);margin-bottom:1.1rem}
+  .hero-label{margin-bottom:1.2rem}
+}
+@media(min-width:769px) and (max-height:700px){
+  .hero-heading{font-size:clamp(2.2rem,6vw,5.2rem)}
+  .hero-tagline{font-size:.72rem}
+}
 
 /* ===== FAST VIDEOLAGER (steget in-loopen bakom scroll-sektionerna) ===== */
 .bgvid-wrap{position:fixed;top:0;left:0;width:100%;height:100%;z-index:1;clip-path:circle(0% at 50% 50%);will-change:clip-path}


### PR DESCRIPTION
På breda men låga fönster (t.ex. 1827×783) blev hero-innehållet högre än skärmen: etiketten "Pizzeria · Djurängsvägen 23 · Kalmar" hamnade över headernavigationen och taglinen kolliderade med Boka bord-knappen.

Åtgärder (endast CSS i `bahkobyra/cloud/pizzeriamatstugan/index.html`):
- Toppmarginal på `.hero-content` så etiketten aldrig når den fasta headern
- Mer reserverat utrymme under taglinen + knappen flyttad närmare sektionens nederkant
- Höjdbaserade media queries (<880px och <700px höjd, endast desktop) som krymper rubriken så alla element alltid får plats

Verifierat med skärmdumpar i 1827×783 (rapporterade fallet), 1920×1080, 1440×900, 1200×700 och 390×844 — inga överlapp, mobilvyn opåverkad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_