### PR TITLE
Bromma Trädgårdsservice: skarp kundsajt (ersätter demon)

### DIFF
--- a/bahkobyra/cloud/brommatradgardsservice/index.html
+++ b/bahkobyra/cloud/brommatradgardsservice/index.html
@@ -3,27 +3,32 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="robots" content="noindex, nofollow">
 <meta name="theme-color" content="#0B0B0D">
-<meta name="description" content="Bromma Trädgårdsservice — gräs, häckar, beskärning och löv i Bromma & Västerort. RUT-avdrag. Demo av Bahko Byrå.">
-<title>Bromma Trädgårdsservice — Din trädgård, hela säsongen</title>
+<title>Bromma Trädgårdsservice — Trädgårdsanläggning &amp; skötsel i Stockholm</title>
+<meta name="description" content="Trädgårdsanläggning, häckplantering, gräsmattor och trädgårdsskötsel i Bromma, Täby, Lidingö, Nacka, Ekerö och Salem. Fast pris innan start, bortforsling ingår. Ring 070-766 65 14.">
+<link rel="canonical" href="https://brommatradgardsservice.se/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Bromma Trädgårdsservice — Trädgårdsanläggning &amp; skötsel i Stockholm">
+<meta property="og:description" content="Från gräsmattor och häckar till kompletta trädgårdsanläggningar. Fast pris innan start, bortforsling ingår.">
+<meta property="og:locale" content="sv_SE">
+<link rel="icon" href="logo.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preconnect" href="https://d8j0ntlcm91z4.cloudfront.net" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;500;600;700;800;900&family=Archivo+Expanded:wght@600;700;800;900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root{
   --bg:#0B0B0D; --bg2:#121215; --card:#17171B;
   --text:#F2EFE9; --muted:rgba(242,239,233,.62); --dim:rgba(242,239,233,.4);
-  --amber:#6BBF59; --amber-lt:#9FE08A; --amber-dk:#3F8F3D; /* Bromma-grön */
+  --amber:#6BBF59; --amber-lt:#9FE08A; --amber-dk:#3F8F3D;
   --line:rgba(242,239,233,.1);
   --grad:linear-gradient(100deg,var(--amber-lt) 0%,var(--amber) 45%,#2E7D32 100%);
-  --sans:'Archivo',system-ui,sans-serif; --disp:'Archivo Expanded','Archivo',sans-serif;
+  --sans:'Archivo',system-ui,sans-serif; --disp:'Archivo',system-ui,sans-serif;
   --ease:cubic-bezier(.22,1,.36,1);
 }
-html{background:var(--bg);scroll-behavior:auto}
-body{background:var(--bg);color:var(--text);font-family:var(--sans);overflow-x:hidden;-webkit-font-smoothing:antialiased;line-height:1.6}
+html{background:var(--bg);scroll-behavior:smooth;overflow-x:hidden;overflow-x:clip}
+body{background:var(--bg);color:var(--text);font-family:var(--sans);overflow-x:hidden;overflow-x:clip;-webkit-font-smoothing:antialiased;line-height:1.6;touch-action:pan-y pinch-zoom}
 a{color:inherit;text-decoration:none}
 button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 ::selection{background:var(--amber);color:#0C1408}
@@ -32,22 +37,22 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 /* ===== LOADER ===== */
 #loader{position:fixed;inset:0;z-index:9999;background:var(--bg);display:flex;flex-direction:column;align-items:center;justify-content:center;transition:opacity .6s ease,visibility .6s ease}
 #loader.hidden{opacity:0;visibility:hidden;pointer-events:none}
-.loader-brand{font-family:var(--disp);font-size:clamp(1.6rem,4.5vw,3rem);font-weight:900;letter-spacing:.25em;margin-bottom:3rem;text-transform:uppercase}
+.loader-brand{font-family:var(--disp);font-size:clamp(1.4rem,4vw,2.4rem);font-weight:900;letter-spacing:.24em;margin-bottom:3rem;text-transform:uppercase}
 .loader-brand em{font-style:normal;color:var(--amber)}
 #loader-bar-wrap{width:min(300px,60vw);height:1px;background:rgba(107,191,89,.2);overflow:hidden}
 #loader-bar{width:0%;height:100%;background:var(--grad);transition:width .3s ease}
 #loader-percent{font-size:.72rem;letter-spacing:.25em;color:var(--dim);margin-top:1.2rem;font-weight:400}
 
 /* ===== HEADER ===== */
-.site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1.6rem,env(safe-area-inset-top)) clamp(1.2rem,4vw,3rem) 1.6rem;display:flex;justify-content:space-between;align-items:center;transition:background .4s,border-color .4s;border-bottom:1px solid transparent}
-.site-header.scrolled{background:rgba(11,11,13,.82);backdrop-filter:blur(18px) saturate(1.2);-webkit-backdrop-filter:blur(18px) saturate(1.2);border-bottom-color:var(--line)}
-.header-logo{font-family:var(--disp);font-weight:900;font-size:1.05rem;letter-spacing:.18em;text-transform:uppercase}
-.header-logo em{font-style:normal;color:var(--amber)}
-.header-nav{display:flex;gap:2.4rem;align-items:center}
+.site-header{position:fixed;top:0;left:0;right:0;z-index:100;padding:max(1rem,env(safe-area-inset-top)) clamp(1.2rem,4vw,3rem) 1rem;display:flex;justify-content:space-between;align-items:center;transition:background .4s,border-color .4s;border-bottom:1px solid transparent}
+.site-header.scrolled{background:rgba(11,11,13,.85);backdrop-filter:blur(18px) saturate(1.2);-webkit-backdrop-filter:blur(18px) saturate(1.2);border-bottom-color:var(--line)}
+.header-logo img{height:56px;width:auto;display:block}
+.header-nav{display:flex;gap:2rem;align-items:center}
 .header-nav a{position:relative;font-size:.68rem;font-weight:600;letter-spacing:.2em;text-transform:uppercase;opacity:.75;transition:opacity .3s,color .3s}
 .header-nav a::after{content:'';position:absolute;left:0;bottom:-5px;height:1px;width:0;background:var(--amber);transition:width .35s var(--ease)}
 .header-nav a:hover{opacity:1;color:var(--amber-lt)}
 .header-nav a:hover::after{width:100%}
+.header-nav .nav-tel{opacity:.9;font-weight:700;color:var(--amber-lt);letter-spacing:.12em}
 .header-nav .nav-cta{opacity:1;background:var(--grad);color:#0C1408;padding:.68rem 1.4rem;border-radius:4px;font-weight:700;box-shadow:0 10px 28px -12px rgba(107,191,89,.55);transition:transform .2s,box-shadow .3s}
 .header-nav .nav-cta::after{display:none}
 .header-nav .nav-cta:hover{transform:translateY(-2px);color:#0C1408;box-shadow:0 16px 36px -12px rgba(107,191,89,.7)}
@@ -58,51 +63,50 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .hamburger.open span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger.open span:nth-child(2){opacity:0}
 .hamburger.open span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
-.mobile-nav{position:fixed;inset:0;background:rgba(11,11,13,.96);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2.4rem;opacity:0;visibility:hidden;transition:all .4s ease}
+.mobile-nav{position:fixed;inset:0;background:rgba(11,11,13,.97);backdrop-filter:blur(20px);z-index:150;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2rem;opacity:0;visibility:hidden;transition:all .4s ease}
 .mobile-nav.open{opacity:1;visibility:visible}
-.mobile-nav a{font-family:var(--disp);font-size:2rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase;opacity:.8;transition:opacity .3s,color .3s}
+.mobile-nav a{font-family:var(--disp);font-size:1.7rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;opacity:.85;transition:opacity .3s,color .3s}
 .mobile-nav a:hover{opacity:1;color:var(--amber)}
+.mobile-nav .mn-tel{font-size:1.1rem;color:var(--amber-lt);letter-spacing:.14em}
 
-/* ===== HERO (förvandlingsvideon loopar som gif) ===== */
+/* ===== HERO ===== */
 .hero-standalone{position:relative;width:100%;height:100svh;display:flex;align-items:center;justify-content:center;overflow:hidden;z-index:10}
 .hero-vid-wrap{position:absolute;inset:0}
 .hero-vid-wrap video{width:100%;height:100%;object-fit:cover}
 .hero-vid-wrap::after{content:'';position:absolute;inset:0;background:
-  linear-gradient(180deg,rgba(11,11,13,.6) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
-.hero-content{position:relative;z-index:2;text-align:center;padding:0 5vw clamp(5rem,12vh,8rem)}
-.hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.42em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:2rem;opacity:0}
-.hero-heading{font-family:var(--disp);font-size:clamp(2.6rem,10.5vw,9.5rem);font-weight:900;line-height:.94;letter-spacing:-.015em;text-transform:uppercase;margin-bottom:1.6rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
-.hero-heading .word{display:inline-block;opacity:0;transform:translateY(60px)}
+  linear-gradient(180deg,rgba(11,11,13,.62) 0%,rgba(11,11,13,.25) 38%,rgba(11,11,13,.35) 68%,rgba(11,11,13,.92) 100%)}
+.hero-content{position:relative;z-index:2;text-align:center;padding:clamp(5rem,11vh,7rem) 5vw clamp(7rem,15vh,10rem)}
+.hero-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.4em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:1.8rem;opacity:0}
+.hero-heading{font-family:var(--disp);font-size:clamp(2.5rem,9.5vw,8rem);font-weight:900;line-height:.96;letter-spacing:-.02em;text-transform:uppercase;margin-bottom:1.5rem;text-shadow:0 8px 50px rgba(0,0,0,.5)}
+.hero-heading .word{display:inline-block;opacity:0;transform:translateY(26px)}
 .hero-heading .accent{background:var(--grad);background-size:220% auto;-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;animation:shimmer 7s linear infinite}
 @keyframes shimmer{to{background-position:220% center}}
-.hero-tagline{font-size:clamp(.74rem,1.1vw,.95rem);font-weight:400;letter-spacing:.18em;color:var(--muted);text-transform:uppercase;opacity:0}
-.hero-scroll-indicator{position:absolute;bottom:2.6rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0;z-index:2}
-.hero-scroll-indicator span{font-size:.58rem;letter-spacing:.32em;color:var(--dim);text-transform:uppercase}
-.scroll-arrow{width:1px;height:42px;position:relative;overflow:hidden}
-.scroll-arrow::after{content:'';position:absolute;top:-100%;left:0;width:1px;height:100%;background:var(--amber);animation:scrollDown 2.1s var(--ease) infinite}
-@keyframes scrollDown{0%{top:-100%}50%{top:0}100%{top:100%}}
+.hero-tagline{font-size:clamp(.74rem,1.1vw,.95rem);font-weight:400;letter-spacing:.16em;color:var(--muted);text-transform:uppercase;opacity:0}
+.hero-scroll-indicator{position:absolute;bottom:max(1.6rem,env(safe-area-inset-bottom));left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.8rem;opacity:0;z-index:2}
+.hero-book-btn{font-size:.66rem;padding:.85rem 2rem}
+@media(min-width:769px) and (max-height:880px){
+  .hero-heading{font-size:clamp(2.4rem,7vw,5.6rem);margin-bottom:1.1rem}
+  .hero-label{margin-bottom:1.1rem}
+}
 
-/* ===== FAST VIDEOLAGER (steget in-loopen bakom scroll-sektionerna) ===== */
+/* ===== FAST VIDEOLAGER ===== */
 .bgvid-wrap{position:fixed;top:0;left:0;width:100%;height:100%;z-index:1;clip-path:circle(0% at 50% 50%);will-change:clip-path}
 .bgvid-wrap video{width:100%;height:100%;object-fit:cover;filter:brightness(.62)}
 .bgvid-wrap::after{content:'';position:absolute;inset:0;background:
   radial-gradient(120% 90% at 50% 50%,transparent 0%,rgba(11,11,13,.66) 100%),
   linear-gradient(180deg,rgba(11,11,13,.45) 0%,transparent 30%,transparent 70%,rgba(11,11,13,.5) 100%)}
 
-/* ===== DARK OVERLAY ===== */
 #dark-overlay{position:fixed;inset:0;background:var(--bg);opacity:0;z-index:3;pointer-events:none;will-change:opacity}
 
 /* ===== SCROLL CONTAINER ===== */
-#scroll-container{position:relative;width:100%;height:700vh;z-index:5}
-
-/* ===== SEKTIONER ===== */
+#scroll-container{position:relative;width:100%;height:520vh;z-index:5}
 .scroll-section{position:absolute;width:100%;display:flex;align-items:center;opacity:0;visibility:hidden;will-change:transform,opacity}
 .scroll-section.active{opacity:1;visibility:visible}
 .align-left{padding-left:6vw;padding-right:50vw}
 .align-right{padding-left:50vw;padding-right:6vw}
 .align-left .section-inner,.align-right .section-inner{max-width:42vw}
 .section-label{display:block;font-size:.66rem;font-weight:600;letter-spacing:.4em;color:var(--amber-lt);text-transform:uppercase;margin-bottom:1.2rem}
-.section-heading{font-family:var(--disp);font-size:clamp(1.9rem,4.6vw,4.4rem);font-weight:900;line-height:1.04;text-transform:uppercase;letter-spacing:-.01em;margin-bottom:1.2rem;text-shadow:0 4px 30px rgba(0,0,0,.5)}
+.section-heading{font-family:var(--disp);font-size:clamp(1.9rem,4.4vw,4rem);font-weight:900;line-height:1.05;text-transform:uppercase;letter-spacing:-.015em;margin-bottom:1.2rem;text-shadow:0 4px 30px rgba(0,0,0,.5)}
 .section-body{font-size:clamp(.86rem,1vw,1rem);font-weight:400;line-height:1.8;color:var(--muted);max-width:480px}
 .section-note{font-size:clamp(.92rem,1.15vw,1.1rem);color:var(--amber-lt);margin-top:1.2rem;font-weight:500;font-style:italic}
 
@@ -119,13 +123,13 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .wcard::after{content:'';position:absolute;inset:0;background:linear-gradient(180deg,transparent 38%,rgba(11,11,13,.94) 100%)}
 .wc-body{position:absolute;left:1.3rem;right:1.3rem;bottom:1.2rem;z-index:2}
 .wc-tag{font-size:.56rem;font-weight:700;letter-spacing:.22em;text-transform:uppercase;color:var(--amber-lt)}
-.wc-body h3{font-family:var(--disp);font-weight:800;font-size:1.25rem;margin:.3rem 0 .2rem}
+.wc-body h3{font-family:var(--disp);font-weight:800;font-size:1.2rem;margin:.3rem 0 .2rem}
 .wc-body p{font-size:.76rem;color:var(--muted)}
 
 /* ===== TJÄNSTER ===== */
-.services-list{display:flex;flex-direction:column;gap:1.6rem}
-.service-item{display:flex;align-items:baseline;gap:1rem;padding-bottom:1.1rem;border-bottom:1px solid rgba(107,191,89,.16)}
-.service-name{font-family:var(--disp);font-size:clamp(1.05rem,1.7vw,1.5rem);font-weight:800;flex:1}
+.services-list{display:flex;flex-direction:column;gap:1.4rem}
+.service-item{display:flex;align-items:baseline;gap:1rem;padding-bottom:1rem;border-bottom:1px solid rgba(107,191,89,.16)}
+.service-name{font-family:var(--disp);font-size:clamp(1rem,1.6vw,1.4rem);font-weight:800;flex:1}
 .service-tag{font-size:.7rem;letter-spacing:.16em;color:var(--amber-lt);font-weight:600;text-transform:uppercase}
 .service-time{font-size:.68rem;color:var(--dim)}
 
@@ -133,9 +137,9 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .section-stats{justify-content:center;text-align:center;padding:0 5vw}
 .stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:clamp(1.5rem,4vw,4rem);max-width:920px;width:100%}
 .stat{display:flex;flex-direction:column;align-items:center;gap:.3rem}
-.stat-number{font-family:var(--disp);font-size:clamp(2.3rem,5vw,4.8rem);font-weight:900;line-height:1}
-.stat-suffix{font-family:var(--disp);font-size:clamp(1.1rem,2vw,1.9rem);font-weight:800;color:var(--amber);margin-left:.08em;display:inline}
-.stat-label{font-size:.58rem;letter-spacing:.26em;text-transform:uppercase;color:var(--dim);margin-top:.35rem}
+.stat-number{font-family:var(--disp);font-size:clamp(2.2rem,4.6vw,4.4rem);font-weight:900;line-height:1}
+.stat-suffix{font-family:var(--disp);font-size:clamp(1.1rem,2vw,1.8rem);font-weight:800;color:var(--amber);margin-left:.08em;display:inline}
+.stat-label{font-size:.58rem;letter-spacing:.24em;text-transform:uppercase;color:var(--dim);margin-top:.35rem}
 
 /* ===== CTA ===== */
 .section-cta{justify-content:center;text-align:center;padding:0 5vw}
@@ -147,48 +151,123 @@ button{font:inherit;cursor:pointer;border:none;background:none;color:inherit}
 .cta-button span,.cta-button svg{position:relative;z-index:1}
 .cta-button svg{width:15px;height:15px;stroke:currentColor;stroke-width:2.4;fill:none;transition:transform .35s var(--ease)}
 .cta-button:hover svg{transform:translateX(4px)}
-.cta-sub{font-size:.6rem;letter-spacing:.24em;color:var(--dim);text-transform:uppercase}
+.cta-sub{font-size:.6rem;letter-spacing:.22em;color:var(--dim);text-transform:uppercase}
 
 /* ===== FLYTANDE OFFERT-KNAPP ===== */
 #float-offert{position:fixed;bottom:max(2.4rem,env(safe-area-inset-bottom));right:2.4rem;z-index:90;background:var(--grad);color:#0C1408;font-size:.64rem;font-weight:800;letter-spacing:.22em;text-transform:uppercase;padding:.85rem 1.7rem;border-radius:4px;opacity:0;transform:translateY(20px);transition:all .4s ease;pointer-events:none;box-shadow:0 10px 30px -8px rgba(107,191,89,.5)}
 #float-offert.visible{opacity:1;transform:translateY(0);pointer-events:auto}
 #float-offert:hover{box-shadow:0 16px 40px -8px rgba(107,191,89,.7);transform:translateY(-2px) scale(1.03)}
 
-/* ===== FOOTER ===== */
-footer{position:relative;z-index:6;border-top:1px solid var(--line);padding:1.8rem clamp(1.2rem,4vw,3rem);display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap;font-size:.7rem;color:var(--dim);background:var(--bg)}
+/* ===== STATISK DEL ===== */
+.static-site{position:relative;z-index:6;background:var(--bg)}
+.ss-section{padding:clamp(4rem,10vh,7rem) clamp(1.2rem,6vw,4rem);border-top:1px solid var(--line)}
+.ss-inner{max-width:1180px;margin:0 auto}
+.ss-label{display:block;font-size:.64rem;font-weight:700;letter-spacing:.36em;color:var(--amber);text-transform:uppercase;margin-bottom:1rem}
+.ss-h2{font-family:var(--disp);font-size:clamp(1.7rem,3.6vw,2.9rem);font-weight:900;line-height:1.1;text-transform:uppercase;letter-spacing:-.015em;margin-bottom:1.4rem}
+.ss-p{font-size:clamp(.9rem,1.05vw,1.02rem);line-height:1.85;color:var(--muted);max-width:640px}
+.ss-p + .ss-p{margin-top:1rem}
+.ss-grid2{display:grid;grid-template-columns:1.05fr .95fr;gap:clamp(2rem,5vw,4rem);align-items:center}
+.ss-img{width:100%;border-radius:10px;border:1px solid var(--line);display:block}
+.ss-list{list-style:none;margin-top:1.6rem;display:grid;grid-template-columns:1fr 1fr;gap:.7rem 1.4rem}
+.ss-list li{position:relative;padding-left:1.5rem;font-size:.9rem;color:var(--muted)}
+.ss-list li::before{content:'';position:absolute;left:0;top:.58em;width:7px;height:7px;border-radius:50%;background:var(--grad)}
+
+/* Tjänstekort */
+.svc-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.1rem;margin-top:2.2rem}
+.svc-card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:1.7rem 1.5rem;transition:border-color .35s,transform .35s}
+.svc-card:hover{border-color:rgba(107,191,89,.45);transform:translateY(-3px)}
+.svc-card h3{font-family:var(--disp);font-weight:800;font-size:1.1rem;margin-bottom:.6rem}
+.svc-card p{font-size:.85rem;color:var(--muted);line-height:1.7}
+.svc-card .svc-tag{display:inline-block;font-size:.55rem;font-weight:700;letter-spacing:.2em;text-transform:uppercase;color:var(--amber-lt);border:1px solid rgba(107,191,89,.3);border-radius:3px;padding:.25rem .6rem;margin-bottom:.9rem}
+
+/* Omdömen */
+.rev-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.1rem;margin-top:2.2rem}
+.rev-card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:1.7rem 1.5rem;display:flex;flex-direction:column}
+.rev-stars{color:var(--amber);font-size:.95rem;letter-spacing:.14em;margin-bottom:.9rem}
+.rev-text{font-size:.88rem;line-height:1.75;color:var(--muted);flex:1}
+.rev-meta{margin-top:1.2rem;padding-top:.9rem;border-top:1px solid var(--line)}
+.rev-name{font-weight:700;font-size:.86rem}
+.rev-job{font-size:.74rem;color:var(--dim);margin-top:.15rem}
+
+/* Områden */
+.area-wrap{display:flex;flex-wrap:wrap;gap:.6rem;margin-top:1.8rem}
+.area-chip{border:1px solid rgba(107,191,89,.28);background:rgba(107,191,89,.06);border-radius:100px;padding:.55rem 1.2rem;font-size:.82rem;color:var(--text)}
+
+/* Process */
+.steps-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1.1rem;margin-top:2.2rem}
+.step-card{background:var(--card);border:1px solid var(--line);border-radius:10px;padding:1.6rem 1.4rem}
+.step-num{font-family:var(--disp);font-weight:900;font-size:1.9rem;line-height:1;background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:.7rem}
+.step-card h3{font-family:var(--disp);font-weight:800;font-size:1rem;margin-bottom:.45rem}
+.step-card p{font-size:.83rem;color:var(--muted);line-height:1.7}
+
+/* Galleri */
+.gallery-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-top:2.2rem}
+.gallery-grid img{width:100%;aspect-ratio:4/3;object-fit:cover;border-radius:10px;border:1px solid var(--line)}
+
+/* Kontakt */
+.contact-wrap{display:grid;grid-template-columns:1fr 1fr;gap:clamp(2rem,5vw,4rem);align-items:start}
+.contact-big{display:block;font-family:var(--disp);font-weight:900;font-size:clamp(1.8rem,4.4vw,3.2rem);letter-spacing:-.01em;background:var(--grad);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;margin:.4rem 0 1.4rem}
+.contact-row{display:flex;gap:.7rem;font-size:.92rem;color:var(--muted);padding:.7rem 0;border-bottom:1px solid var(--line)}
+.contact-row strong{color:var(--text);min-width:104px;font-weight:600}
+.offer-card{background:var(--card);border:1px solid rgba(107,191,89,.28);border-radius:12px;padding:2rem 1.8rem}
+.offer-card h3{font-family:var(--disp);font-weight:800;font-size:1.35rem;margin-bottom:.7rem}
+.offer-card p{font-size:.88rem;color:var(--muted);margin-bottom:1.5rem}
+.offer-card .cta-button{width:100%;justify-content:center}
+
+footer{position:relative;z-index:6;border-top:1px solid var(--line);padding:2rem clamp(1.2rem,4vw,3rem);display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap;font-size:.72rem;color:var(--dim);background:var(--bg)}
 footer a{color:var(--amber-lt)}
 
-/* ===== MODAL (Bahko demo) ===== */
-.modal-bg{position:fixed;inset:0;z-index:500;background:rgba(11,11,13,.72);backdrop-filter:blur(10px);display:grid;place-items:center;padding:1.2rem;opacity:0;visibility:hidden;transition:.35s}
+/* ===== MODAL / OFFERTFORMULÄR ===== */
+.modal-bg{position:fixed;inset:0;z-index:500;background:rgba(11,11,13,.75);backdrop-filter:blur(10px);display:grid;place-items:center;padding:1.2rem;opacity:0;visibility:hidden;transition:.35s;overflow-y:auto}
 .modal-bg.open{opacity:1;visibility:visible}
-.modal{background:var(--bg2);border:1px solid rgba(107,191,89,.3);border-radius:12px;max-width:480px;width:100%;padding:2.6rem;position:relative;box-shadow:0 40px 110px rgba(0,0,0,.6)}
+.modal{background:var(--bg2);border:1px solid rgba(107,191,89,.3);border-radius:12px;max-width:540px;width:100%;padding:2.4rem;position:relative;box-shadow:0 40px 110px rgba(0,0,0,.6);margin:auto}
 .modal-x{position:absolute;top:1rem;right:1.2rem;font-size:1.3rem;color:var(--dim);padding:.4rem}
 .modal-x:hover{color:var(--text)}
-.m-badge{display:inline-block;font-size:.58rem;letter-spacing:.24em;text-transform:uppercase;color:var(--amber-lt);background:rgba(107,191,89,.1);border:1px solid rgba(107,191,89,.25);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.3rem}
-.modal h3{font-family:var(--disp);font-weight:800;font-size:1.7rem;line-height:1.15;margin-bottom:.6rem}
-.modal p{font-size:.88rem;color:var(--muted);margin-bottom:1.6rem}
-.modal .cta-button{width:100%;justify-content:center;font-size:.72rem;padding:1rem 1.4rem}
-.m-alt{display:block;text-align:center;font-size:.74rem;color:var(--dim);margin-top:1rem;transition:color .3s}
-.m-alt:hover{color:var(--amber-lt)}
-.m-foot{margin-top:1.6rem;padding-top:1.1rem;border-top:1px solid var(--line);text-align:center;font-size:.62rem;letter-spacing:.16em;color:var(--dim)}
-.m-foot a{color:var(--amber-lt);font-weight:600}
+.m-badge{display:inline-block;font-size:.58rem;letter-spacing:.24em;text-transform:uppercase;color:var(--amber-lt);background:rgba(107,191,89,.1);border:1px solid rgba(107,191,89,.25);border-radius:4px;padding:.35rem .8rem;margin-bottom:1.2rem}
+.modal h3{font-family:var(--disp);font-weight:800;font-size:1.55rem;line-height:1.15;margin-bottom:.5rem}
+.modal p.m-sub{font-size:.87rem;color:var(--muted);margin-bottom:1.5rem}
+.of-form{display:grid;grid-template-columns:1fr 1fr;gap:.9rem}
+.of-field{display:flex;flex-direction:column;gap:.35rem}
+.of-field.full{grid-column:1/-1}
+.of-field label{font-size:.62rem;letter-spacing:.18em;text-transform:uppercase;color:var(--dim);font-weight:600}
+.of-field input,.of-field select,.of-field textarea{background:rgba(242,239,233,.05);border:1px solid var(--line);border-radius:6px;padding:.75rem .85rem;color:var(--text);font-family:inherit;font-size:.9rem;transition:border-color .25s}
+.of-field input:focus,.of-field select:focus,.of-field textarea:focus{outline:none;border-color:var(--amber)}
+.of-field textarea{resize:vertical;min-height:78px}
+.of-field select option{background:var(--bg2);color:var(--text)}
+.of-form .cta-button{grid-column:1/-1;width:100%;justify-content:center;margin-top:.5rem}
+.of-note{grid-column:1/-1;font-size:.7rem;color:var(--dim);text-align:center;line-height:1.6}
+#of-summary{display:none}
+#of-summary.show{display:block}
+.of-sum-box{background:rgba(107,191,89,.07);border:1px solid rgba(107,191,89,.25);border-radius:8px;padding:1.2rem 1.3rem;margin-bottom:1.4rem;font-size:.88rem;line-height:1.9}
+.of-sum-box b{color:var(--amber-lt)}
+.of-actions{display:flex;flex-direction:column;gap:.7rem}
+.of-actions .cta-button{width:100%;justify-content:center}
+.of-tel{display:flex;align-items:center;justify-content:center;gap:.6rem;border:1px solid rgba(107,191,89,.35);border-radius:4px;padding:1rem;font-weight:700;letter-spacing:.12em;color:var(--amber-lt);font-size:.9rem}
+.of-tel:hover{background:rgba(107,191,89,.08)}
 
 /* ===== MOBIL ===== */
 @media(max-width:768px){
   .header-nav{display:none}
   .hamburger{display:flex}
+  .header-logo img{height:44px}
   .align-left,.align-right{padding-left:6vw;padding-right:6vw}
   .align-left .section-inner,.align-right .section-inner{max-width:100%}
-  .scroll-section .section-inner{background:rgba(11,11,13,.74);backdrop-filter:blur(8px);padding:1.8rem;border-radius:8px;border:1px solid var(--line)}
-  #scroll-container{height:500vh}
+  .scroll-section .section-inner{background:rgba(11,11,13,.76);backdrop-filter:blur(8px);padding:1.7rem;border-radius:8px;border:1px solid var(--line)}
+  #scroll-container{height:620vh}
   .work-grid{grid-template-columns:1fr;gap:.9rem}
   .wcard{aspect-ratio:4/2.8}
   .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.8rem}
-  .hero-heading{font-size:clamp(2.3rem,11vw,5rem)}
+  .hero-heading{font-size:clamp(2.2rem,10vw,4.4rem)}
   .cta-button{padding:.95rem 2rem;width:100%;justify-content:center}
+  .hero-book-btn{width:auto;white-space:nowrap;padding:.9rem 1.8rem}
   #float-offert{bottom:max(1.4rem,env(safe-area-inset-bottom));right:1.4rem;font-size:.58rem;padding:.72rem 1.3rem}
-  .modal{padding:1.8rem 1.4rem}
+  .modal{padding:1.8rem 1.3rem}
   .service-item{flex-direction:column;gap:.3rem;align-items:flex-start}
+  .ss-grid2,.contact-wrap{grid-template-columns:1fr}
+  .ss-list{grid-template-columns:1fr}
+  .svc-grid,.rev-grid,.gallery-grid{grid-template-columns:1fr}
+  .steps-grid{grid-template-columns:repeat(2,1fr)}
+  .of-form{grid-template-columns:1fr}
 }
 html.fallback #loader{display:none}
 html.fallback #scroll-container{height:auto}
@@ -197,6 +276,7 @@ html.fallback .hero-label,html.fallback .hero-tagline,html.fallback .hero-scroll
 html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
 @media(prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
+  html{scroll-behavior:auto}
   #loader{display:none}
   #scroll-container{height:auto}
   .scroll-section{position:static;opacity:1!important;visibility:visible!important;transform:none!important;padding-top:4rem;padding-bottom:4rem}
@@ -217,146 +297,152 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
 
 <!-- MOBILNAV -->
 <nav class="mobile-nav" id="mobile-nav">
-  <a href="#" onclick="closeMobileNav()">Projekt</a>
-  <a href="#" onclick="closeMobileNav()">Tjänster</a>
-  <a href="#" onclick="closeMobileNav()">Om Oss</a>
-  <a href="#" onclick="openModal();closeMobileNav()">Begär Offert</a>
+  <a href="#tjanster" onclick="closeMobileNav()">Tjänster</a>
+  <a href="#omdomen" onclick="closeMobileNav()">Omdömen</a>
+  <a href="#om-oss" onclick="closeMobileNav()">Om oss</a>
+  <a href="#omraden" onclick="closeMobileNav()">Områden</a>
+  <a href="#kontakt" onclick="closeMobileNav()">Kontakt</a>
+  <a class="mn-tel" href="tel:+46707666514">070-766 65 14</a>
+  <a href="#" onclick="openOffert();closeMobileNav();return false">Begär offert</a>
 </nav>
 
 <!-- HEADER -->
 <header class="site-header" id="site-header">
-  <a href="#" class="header-logo">BROMMA<em>.</em></a>
+  <a href="#" class="header-logo" aria-label="Bromma Trädgårdsservice"><img src="logo.svg" alt="Bromma Trädgårdsservice"></a>
   <nav class="header-nav">
-    <a href="#">Projekt</a>
-    <a href="#">Tjänster</a>
-    <a href="#">Om Oss</a>
-    <a href="#" class="nav-cta" onclick="openModal();return false">Begär Offert</a>
+    <a href="#tjanster">Tjänster</a>
+    <a href="#omdomen">Omdömen</a>
+    <a href="#om-oss">Om oss</a>
+    <a href="#kontakt">Kontakt</a>
+    <a href="tel:+46707666514" class="nav-tel">070-766 65 14</a>
+    <a href="#" class="nav-cta" onclick="openOffert();return false">Begär offert</a>
   </nav>
   <button class="hamburger" id="hamburger" onclick="toggleMobileNav()" aria-label="Meny">
     <span></span><span></span><span></span>
   </button>
 </header>
 
-<!-- HERO — förvandlingsvideon loopar som gif -->
+<!-- HERO -->
 <section class="hero-standalone">
   <div class="hero-vid-wrap">
     <video id="hero-vid" autoplay muted loop playsinline preload="auto"
       poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222739_95c29488-7c11-4354-a052-fe1e59d8f03e.png"
-      src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_223053_08178cf6-f2f6-474d-9494-92ed6f5686f0.mp4"></video>
+      src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_223053_08178cf6-f2f6-474d-9494-92ed6f5686f0.mp4"></video>
   </div>
   <div class="hero-content">
-    <span class="hero-label">Trädgårdsskötsel &amp; underhåll · Bromma &amp; Västerort</span>
+    <span class="hero-label">Trädgårdsanläggning &amp; skötsel · Stockholm</span>
     <h1 class="hero-heading">
-      <span class="word">Din trädgård.</span><br>
-      <span class="word accent">Hela säsongen.</span>
+      <span class="word">Trädgården ni</span><br>
+      <span class="word accent">alltid velat ha.</span>
     </h1>
-    <p class="hero-tagline">Gräs · Häckar · Beskärning · Löv — med RUT-avdrag</p>
+    <p class="hero-tagline">Fast pris innan start · Bortforsling ingår · En kontakt hela vägen</p>
   </div>
   <div class="hero-scroll-indicator">
-    <span>Se förvandlingen</span>
-    <div class="scroll-arrow"></div>
+    <button class="cta-button hero-book-btn" onclick="openOffert()">
+      <span>Begär offert</span>
+      <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+    </button>
   </div>
 </section>
 
-<!-- FAST VIDEOLAGER — steget in-loopen bakom sektionerna -->
+<!-- FAST VIDEOLAGER -->
 <div class="bgvid-wrap" id="bgvid-wrap">
   <video id="bg-vid" autoplay muted loop playsinline preload="metadata"
     poster="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222907_abd794d7-4c74-4996-b84a-0c8efd723860.png"
-    src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_223121_4151110e-f0ac-40ea-bc63-0be4c6dfbe30.mp4"></video>
+    src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_223121_4151110e-f0ac-40ea-bc63-0be4c6dfbe30.mp4"></video>
 </div>
 <div id="dark-overlay"></div>
 
 <!-- SCROLL CONTAINER -->
 <div id="scroll-container">
 
-  <section class="scroll-section align-left" data-enter="8" data-leave="22" data-animation="slide-left">
+  <section class="scroll-section align-left" data-enter="3" data-leave="24" data-animation="slide-left">
     <div class="section-inner">
-      <span class="section-label">001 / Filosofi</span>
-      <h2 class="section-heading">En trädgård som<br>håller sig fin.</h2>
-      <p class="section-body">En klippning gör skillnad i en vecka. Ett skötselavtal gör skillnad hela året: gräs och häckar nu i sommar, beskärning och löv i höst, snöröjning när det vänder. En kontakt, ett upplägg — och en trädgård som alltid är redo för kaffe ute.</p>
-      <p class="section-note">"Du ska njuta av trädgården. Vi sköter resten."</p>
+      <span class="section-label">001 / Så jobbar vi</span>
+      <h2 class="section-heading">Ni ska slippa<br>tre olika firmor.</h2>
+      <p class="section-body">De flesta trädgårdsprojekt stannar upp på samma ställe: en firma gräver, en annan levererar jord, en tredje forslar bort skräpet. Vi tar hela kedjan själva, från beställning av material till att sista lasset är borta. Ni har en kontakt, ett pris, och vet exakt vad som händer varje dag.</p>
+      <p class="section-note">"Priset ni får är priset ni betalar."</p>
     </div>
   </section>
 
-  <section class="scroll-section section-projects" data-enter="26" data-leave="42" data-animation="stagger-up">
+  <section class="scroll-section section-projects" data-enter="28" data-leave="45" data-animation="stagger-up">
     <div class="projects-inner">
       <div class="projects-head">
-        <span class="section-label">002 / Projekt</span>
-        <h2 class="section-heading">Veckans jobb.<br><span class="grad-text">Rad för rad.</span></h2>
-        <p>Tre uppdrag ur flödet — gräs, häckar och rabatter.</p>
+        <span class="section-label">002 / Vad vi gör</span>
+        <h2 class="section-heading">Från tomt<br><span class="grad-text">till trädgård.</span></h2>
+        <p>Anläggning, gräsmattor och häckar, i hela Storstockholm.</p>
       </div>
       <div class="work-grid">
         <article class="wcard">
-          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222929_6e26ef20-fa63-42d4-b7fb-dc99bcfde1be.png" alt="Nyklippt gräsmatta med skarpa kanter" loading="lazy">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222929_6e26ef20-fa63-42d4-b7fb-dc99bcfde1be.png" alt="Nyanlagd gräsmatta med skarpa kanter" loading="lazy">
           <div class="wc-body">
             <div class="wc-tag">Gräsmatta</div>
-            <h3>Klippt &amp; kantskuret</h3>
-            <p>Återkommande klippning med skarpa kanter — varannan vecka.</p>
+            <h3>Ny gräsmatta</h3>
+            <p>Jordutjämning, rullgräs och sprinklers, klart att gå på.</p>
           </div>
         </article>
         <article class="wcard">
-          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222940_c515be9b-b326-48b8-8373-9837f2c3e99e.png" alt="Nyklippt häck med raka linjer" loading="lazy">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222940_c515be9b-b326-48b8-8373-9837f2c3e99e.png" alt="Nyplanterad häck med raka linjer" loading="lazy">
           <div class="wc-body">
-            <div class="wc-tag">Häckar</div>
-            <h3>Häckklippning</h3>
-            <p>Raka linjer och rena snitt — bortforsling ingår alltid.</p>
+            <div class="wc-tag">Häck</div>
+            <h3>Häckplantering</h3>
+            <p>Gammal häck bort, ny på plats. Material och bortforsling ingår.</p>
           </div>
         </article>
         <article class="wcard">
-          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222952_eeb0a9f2-1433-40fa-890e-d4c049a9de17.png" alt="Nyplanterad rabatt med sommarblommor" loading="lazy">
+          <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222952_eeb0a9f2-1433-40fa-890e-d4c049a9de17.png" alt="Anlagd trädgård med planteringar" loading="lazy">
           <div class="wc-body">
-            <div class="wc-tag">Rabatter</div>
-            <h3>Rabatt &amp; plantering</h3>
-            <p>Rensat, ny jord och säsongens växter — klart att blomma.</p>
+            <div class="wc-tag">Anläggning</div>
+            <h3>Trädgårdsanläggning</h3>
+            <p>Hela tomten, planerad och utförd från grunden.</p>
           </div>
         </article>
       </div>
     </div>
   </section>
 
-  <section class="scroll-section align-right" data-enter="46" data-leave="60" data-animation="slide-right">
+  <section class="scroll-section align-right" data-enter="49" data-leave="63" data-animation="slide-right">
     <div class="section-inner">
       <span class="section-label">003 / Tjänster</span>
-      <h2 class="section-heading">Året om.<br>Samma kontakt.</h2>
+      <h2 class="section-heading">Hela trädgården.<br>Samma firma.</h2>
       <div class="services-list">
         <div class="service-item">
-          <span class="service-name">Gräsklippning</span>
-          <span class="service-tag">RUT-avdrag</span>
-          <span class="service-time">Återkommande · Sommar</span>
+          <span class="service-name">Trädgårdsanläggning</span>
+          <span class="service-tag">Fast pris</span>
+          <span class="service-time">Hela projekt</span>
         </div>
         <div class="service-item">
-          <span class="service-name">Häckar &amp; beskärning</span>
-          <span class="service-tag">RUT-avdrag</span>
-          <span class="service-time">Vår &amp; sensommar</span>
+          <span class="service-name">Gräsmatta &amp; sprinklers</span>
+          <span class="service-tag">Fast pris</span>
+          <span class="service-time">Rullgräs · Bevattning</span>
         </div>
         <div class="service-item">
-          <span class="service-name">Lövupptagning &amp; trädgårdsstäd</span>
-          <span class="service-tag">RUT-avdrag</span>
-          <span class="service-time">Vår &amp; höst</span>
+          <span class="service-name">Häckplantering &amp; borttagning</span>
+          <span class="service-tag">Fast pris</span>
+          <span class="service-time">Material ingår</span>
         </div>
         <div class="service-item">
-          <span class="service-name">Snöröjning &amp; halkbekämpning</span>
-          <span class="service-tag">Säsongsavtal</span>
-          <span class="service-time">Vinter — samma kontakt</span>
+          <span class="service-name">Trädgårdsskötsel</span>
+          <span class="service-tag">RUT-avdrag</span>
+          <span class="service-time">Löpande · Hela säsongen</span>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- OBS: stats = erbjudandevillkor + RUT-fakta (50 % enligt lag) — justeras med kunden före skarp lansering -->
-  <section class="scroll-section section-stats" data-enter="64" data-leave="78" data-animation="stagger-up">
+  <section class="scroll-section section-stats" data-enter="67" data-leave="80" data-animation="stagger-up">
     <div class="stats-grid">
       <div class="stat">
-        <div><span class="stat-number" data-value="50" data-decimals="0">0</span><span class="stat-suffix">%</span></div>
-        <span class="stat-label">RUT-avdrag på arbetet</span>
+        <div><span class="stat-number" data-value="100" data-decimals="0">0</span><span class="stat-suffix">%</span></div>
+        <span class="stat-label">Fast pris innan start</span>
       </div>
       <div class="stat">
-        <div><span class="stat-number" data-value="48" data-decimals="0">0</span><span class="stat-suffix"> h</span></div>
+        <div><span class="stat-number" data-value="24" data-decimals="0">0</span><span class="stat-suffix"> h</span></div>
         <span class="stat-label">Svar på förfrågan</span>
       </div>
       <div class="stat">
-        <div><span class="stat-number" data-value="4" data-decimals="0">0</span><span class="stat-suffix"> årstider</span></div>
-        <span class="stat-label">Ett avtal — året om</span>
+        <div><span class="stat-number" data-value="1" data-decimals="0">0</span><span class="stat-suffix"></span></div>
+        <span class="stat-label">Kontaktperson</span>
       </div>
       <div class="stat">
         <div><span class="stat-number" data-value="0" data-decimals="0">0</span><span class="stat-suffix"> kr</span></div>
@@ -368,37 +454,348 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
   <section class="scroll-section section-cta" data-enter="84" data-leave="100" data-animation="scale-up" data-persist="true">
     <div class="cta-inner">
       <span class="section-label">Nästa steg</span>
-      <h2 class="section-heading" style="font-size:clamp(2.4rem,6.5vw,6rem)">Dags att njuta av<br><span class="grad-text">trädgården?</span></h2>
-      <button class="cta-button" onclick="openModal()">
+      <h2 class="section-heading" style="font-size:clamp(2.2rem,6vw,5.2rem)">Vad ska göras<br><span class="grad-text">i er trädgård?</span></h2>
+      <button class="cta-button" onclick="openOffert()">
         <span>Begär kostnadsfri offert</span>
         <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
       </button>
-      <span class="cta-sub">Svar inom 48h · RUT-avdrag · Säsongsavtal eller engångsjobb</span>
+      <span class="cta-sub">Svar inom 24h · Fast pris · Bortforsling ingår</span>
     </div>
   </section>
 
 </div>
 
 <!-- FLYTANDE OFFERT-KNAPP -->
-<button id="float-offert" onclick="openModal()">Begär offert</button>
+<button id="float-offert" onclick="openOffert()">Begär offert</button>
+
+<!-- ===================== STATISK DEL ===================== -->
+<div class="static-site">
+
+  <!-- TJÄNSTER -->
+  <section class="ss-section" id="tjanster">
+    <div class="ss-inner">
+      <span class="ss-label">Tjänster</span>
+      <h2 class="ss-h2">Det vi gör, och gör klart</h2>
+      <p class="ss-p">Vi tar både engångsprojekt och löpande skötsel. Oavsett vilket får ni fast pris innan vi sätter spaden i marken, och bortforsling av allt gammalt ingår alltid.</p>
+
+      <div class="svc-grid">
+        <article class="svc-card">
+          <span class="svc-tag">Anläggning</span>
+          <h3>Trädgårdsanläggning</h3>
+          <p>Kompletta projekt från planering till färdig trädgård. Vi jämnar ut marken, beställer och tar emot material, anlägger, och forslar bort det gamla. Ni får visuella förslag innan vi börjar, så ni vet vad ni betalar för.</p>
+        </article>
+        <article class="svc-card">
+          <span class="svc-tag">Gräs</span>
+          <h3>Gräsmatta &amp; sprinklersystem</h3>
+          <p>Ny gräsmatta på rätt underlag, inte bara utrullad på gammal jord. Vi jämnar ut, förbereder växtbädden och lägger rullgräs. Sprinklersystem installerar vi samtidigt, oavsett om ni köpt det själva eller vill att vi ordnar det.</p>
+        </article>
+        <article class="svc-card">
+          <span class="svc-tag">Häck</span>
+          <h3>Häckplantering &amp; borttagning</h3>
+          <p>Tujahäck, ligusterhäck eller annan häck, planterad på rätt djup med rätt jord och täckmaterial. Ska den gamla häcken bort tar vi rothalsen med, och kör bort allt samma dag.</p>
+        </article>
+        <article class="svc-card">
+          <span class="svc-tag">Skötsel</span>
+          <h3>Trädgårdsskötsel</h3>
+          <p>Löpande skötsel för er som vill slippa tänka på det: gräsklippning, häckklippning, ogräsrensning och beskärning genom hela säsongen. Här gäller RUT-avdrag på arbetskostnaden.</p>
+        </article>
+        <article class="svc-card">
+          <span class="svc-tag">Mark</span>
+          <h3>Jordutjämning &amp; markarbete</h3>
+          <p>Ojämn tomt, gropar eller fel lutning som gör att vattnet blir stående? Vi jämnar ut, fyller på och packar rätt, så att gräset och planteringarna faktiskt överlever nästa regnperiod.</p>
+        </article>
+        <article class="svc-card">
+          <span class="svc-tag">Bortforsling</span>
+          <h3>Röjning &amp; bortforsling</h3>
+          <p>Gammal häck, ris, jordmassor eller trädgårdsavfall. Vi lastar och kör bort. Detta ingår redan i våra projekt, men vi tar det också som fristående uppdrag.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- OMDÖMEN -->
+  <section class="ss-section" id="omdomen">
+    <div class="ss-inner">
+      <span class="ss-label">Omdömen</span>
+      <h2 class="ss-h2">Vad kunderna faktiskt säger</h2>
+      <p class="ss-p">Riktiga omdömen från kunder i Stockholmsområdet.</p>
+
+      <div class="rev-grid">
+        <article class="rev-card">
+          <div class="rev-stars">★★★★★</div>
+          <p class="rev-text">Jag är otroligt nöjd med servicen, verkligen en helhetslösning från början till slut. Jens är mycket kunnig, effektiv och snabb i sitt arbete. De hjälpte till med hela häckprojektet, från beställning av material till leverans av jord och täckmaterial, samt borttagning och bortforsling av den gamla häcken. Priset var dessutom mycket rimligt, lägre än många andra företag.</p>
+          <div class="rev-meta">
+            <div class="rev-name">Sifat Bin</div>
+            <div class="rev-job">Trädgårdsskötsel, Rönninge · april 2026</div>
+          </div>
+        </article>
+
+        <article class="rev-card">
+          <div class="rev-stars">★★★★★</div>
+          <p class="rev-text">Helt fantastiskt jobb från start till slut! Firman kom ut och utjämnade jorden i vår trädgård och vi kunde inte vara nöjdare. De var otroligt proffsiga, snabba och effektiva. Trots att det var ett krävande jobb kämpade de på utan att tumma på kvaliteten. Rekommenderas starkt!</p>
+          <div class="rev-meta">
+            <div class="rev-name">Christoffer</div>
+            <div class="rev-job">Trädgårdsanläggning 150 kvm, Saltsjö-Boo · mars 2026</div>
+          </div>
+        </article>
+
+        <article class="rev-card">
+          <div class="rev-stars">★★★★★</div>
+          <p class="rev-text">Vi är supernöjda med vår nya tujahäck! Från första kontakt har det varit otroligt smidigt, de är extremt pålitliga och lätta att kommunicera med. Det märks att de kan sin sak, vi kunde diskutera olika lösningar och fick ett proffsigt bemötande hela vägen. Arbetet utfördes snabbt, noggrant och med ett strålande resultat.</p>
+          <div class="rev-meta">
+            <div class="rev-name">Marta</div>
+            <div class="rev-job">Tujahäck 20 meter, Rönninge · mars 2026</div>
+          </div>
+        </article>
+
+        <article class="rev-card">
+          <div class="rev-stars">★★★★★</div>
+          <p class="rev-text">Snabba, duktiga och klart inom budget. Satte in ny gräsmatta på en besvärlig tomt med mycket manuellt arbete. De satte även in sprinklers vi hade köpt på ett bra sätt.</p>
+          <div class="rev-meta">
+            <div class="rev-name">Martin</div>
+            <div class="rev-job">Gräsmatta 100 kvm, Lidingö · juni 2026</div>
+          </div>
+        </article>
+
+        <article class="rev-card">
+          <div class="rev-stars">★★★★★</div>
+          <p class="rev-text">Mycket professionellt utfört arbete. Kom i tid och höll utlovad plan. Rekommenderas starkt!</p>
+          <div class="rev-meta">
+            <div class="rev-name">Thomas</div>
+            <div class="rev-job">Trädgårdsskötsel 301–500 kvm, Ekerö · juni 2026</div>
+          </div>
+        </article>
+
+        <article class="rev-card">
+          <div class="rev-stars">★★★★★</div>
+          <p class="rev-text">Killarna gjorde det lilla extra, bokade direkt in ett till jobb.</p>
+          <div class="rev-meta">
+            <div class="rev-name">Fredrik</div>
+            <div class="rev-job">Trädgårdsskötsel 700 kvm, Täby · maj 2026</div>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- OM OSS -->
+  <section class="ss-section" id="om-oss">
+    <div class="ss-inner ss-grid2">
+      <div>
+        <span class="ss-label">Om oss</span>
+        <h2 class="ss-h2">Vi gör trädgårdar. Hela vägen.</h2>
+        <p class="ss-p">Bromma Trädgårdsservice är ett litet team som tar hand om hela trädgårdsprojektet själva. Jens leder jobben på plats och är den ni pratar med, från första besök till att sista lasset är bortkört.</p>
+        <p class="ss-p">Vi jobbar med både villaägare som vill anlägga om hela tomten och kunder som bara vill ha en häck planterad eller gräsmattan skött genom säsongen. Oavsett storlek får ni fast pris innan vi börjar, och vi säger till direkt om vi tycker att något inte behöver göras.</p>
+        <ul class="ss-list">
+          <li>Fast pris innan start</li>
+          <li>Bortforsling ingår</li>
+          <li>Material och jord ordnas av oss</li>
+          <li>En kontaktperson hela vägen</li>
+          <li>Visuella förslag innan vi börjar</li>
+          <li>Hela Storstockholm</li>
+        </ul>
+      </div>
+      <div>
+        <img class="ss-img" src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222952_eeb0a9f2-1433-40fa-890e-d4c049a9de17.png" alt="Anlagd trädgård med planteringar och gräsmatta" loading="lazy">
+      </div>
+    </div>
+  </section>
+
+  <!-- OMRÅDEN -->
+  <section class="ss-section" id="omraden">
+    <div class="ss-inner">
+      <span class="ss-label">Områden</span>
+      <h2 class="ss-h2">Var vi jobbar</h2>
+      <p class="ss-p">Vi utgår från Bromma och tar jobb i hela Storstockholm. Är ni osäkra på om vi kör till er, ring så säger vi rakt ut.</p>
+      <div class="area-wrap">
+        <span class="area-chip">Bromma</span>
+        <span class="area-chip">Västerort</span>
+        <span class="area-chip">Täby</span>
+        <span class="area-chip">Lidingö</span>
+        <span class="area-chip">Nacka</span>
+        <span class="area-chip">Saltsjö-Boo</span>
+        <span class="area-chip">Ekerö</span>
+        <span class="area-chip">Salem</span>
+        <span class="area-chip">Rönninge</span>
+        <span class="area-chip">Solna</span>
+        <span class="area-chip">Sundbyberg</span>
+        <span class="area-chip">Stockholm</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- PROCESS -->
+  <section class="ss-section" id="process">
+    <div class="ss-inner">
+      <span class="ss-label">Så går det till</span>
+      <h2 class="ss-h2">Fyra steg, inga överraskningar</h2>
+      <div class="steps-grid">
+        <article class="step-card">
+          <div class="step-num">01</div>
+          <h3>Ni hör av er</h3>
+          <p>Ring eller skicka en förfrågan. Ni får svar inom 24 timmar, av den som faktiskt kommer utföra jobbet.</p>
+        </article>
+        <article class="step-card">
+          <div class="step-num">02</div>
+          <h3>Vi kommer ut</h3>
+          <p>Vi tittar på tomten, går igenom vad ni vill ha och säger ärligt vad som inte behöver göras. Kostar ingenting.</p>
+        </article>
+        <article class="step-card">
+          <div class="step-num">03</div>
+          <h3>Fast pris</h3>
+          <p>Ni får ett pris med allt inräknat: arbete, material, jord och bortforsling. Det priset står sig.</p>
+        </article>
+        <article class="step-card">
+          <div class="step-num">04</div>
+          <h3>Vi gör klart</h3>
+          <p>Vi utför jobbet på utsatt tid och lämnar tomten städad. Sista lasset kör vi bort själva.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- GALLERI -->
+  <section class="ss-section" id="galleri">
+    <div class="ss-inner">
+      <span class="ss-label">Galleri</span>
+      <h2 class="ss-h2">Färdiga jobb</h2>
+      <div class="gallery-grid">
+        <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222929_6e26ef20-fa63-42d4-b7fb-dc99bcfde1be.png" alt="Nyanlagd gräsmatta i villaträdgård" loading="lazy">
+        <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222940_c515be9b-b326-48b8-8373-9837f2c3e99e.png" alt="Nyplanterad häck längs tomtgräns" loading="lazy">
+        <img src="https://d8j0ntlcm91z4.cloudfront.net/user_303UGjarlF5o5kNsAwtwUgTZYoI/hf_20260611_222952_eeb0a9f2-1433-40fa-890e-d4c049a9de17.png" alt="Anlagd trädgård med planteringar" loading="lazy">
+      </div>
+    </div>
+  </section>
+
+  <!-- KONTAKT -->
+  <section class="ss-section" id="kontakt">
+    <div class="ss-inner contact-wrap">
+      <div>
+        <span class="ss-label">Kontakt</span>
+        <h2 class="ss-h2">Ring oss</h2>
+        <a class="contact-big" href="tel:+46707666514">070-766 65 14</a>
+        <div class="contact-row"><strong>E-post</strong><a href="mailto:jens@brommatradgardsservice.se">jens@brommatradgardsservice.se</a></div>
+        <div class="contact-row"><strong>Område</strong><span>Bromma och hela Storstockholm</span></div>
+        <div class="contact-row"><strong>Svarstid</strong><span>Inom 24 timmar på vardagar</span></div>
+        <div class="contact-row"><strong>Offert</strong><span>Kostnadsfri, på plats</span></div>
+      </div>
+      <div class="offer-card">
+        <h3>Begär offert</h3>
+        <p>Berätta kort vad som ska göras, så hör vi av oss inom 24 timmar med ett fast pris.</p>
+        <button class="cta-button" onclick="openOffert()">
+          <span>Skicka förfrågan</span>
+          <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        </button>
+      </div>
+    </div>
+  </section>
+
+</div>
 
 <footer>
-  <span>Bromma Trädgårdsservice · Demo</span>
-  <span>Byggd av <a href="https://bahkobyra.se" target="_blank" rel="noopener">Bahko Byrå</a></span>
+  <span>Bromma Trädgårdsservice · 070-766 65 14 · Storstockholm</span>
+  <span>Hemsida av <a href="https://bahkobyra.se" target="_blank" rel="noopener">Bahko Byrå</a></span>
 </footer>
 
-<!-- BAHKO DEMO-MODAL -->
-<div class="modal-bg" id="modal">
+<!-- OFFERTMODAL -->
+<div class="modal-bg" id="offert-modal">
   <div class="modal">
-    <button class="modal-x" onclick="closeModal()" aria-label="Stäng">✕</button>
-    <div class="m-badge">Demo av Bahko Byrå</div>
-    <h3>Vill du ha en sida som denna för ditt företag?</h3>
-    <p>Boka ett kostnadsfritt 15-minuterssamtal med Mathias. Vi visar exakt hur din firmas hemsida kan se ut — och hur den drar in offertförfrågningar.</p>
-    <button class="cta-button" data-cal-namespace="15min" data-cal-link="bahkobyra/15min" data-cal-origin="https://cal.eu"><span>Boka 15 min gratis samtal →</span></button>
-    <a class="m-alt" href="mailto:mathias@bahkobyra.se?subject=Intresserad av demo-hemsida (bygg)&body=Hej Mathias, jag såg Bromma Trädgårdsservice-demon och vill veta mer.">Eller mejla → mathias@bahkobyra.se</a>
-    <div class="m-foot"><a href="https://bahkobyra.se" target="_blank" rel="noopener">Bahko Byrå</a> · Synlighet som säljer.</div>
+    <button class="modal-x" onclick="closeOffert()" aria-label="Stäng">✕</button>
+
+    <div id="of-step1">
+      <div class="m-badge">Kostnadsfri offert</div>
+      <h3>Vad ska göras i trädgården?</h3>
+      <p class="m-sub">Fyll i kort så återkommer vi inom 24 timmar med ett fast pris.</p>
+      <form class="of-form" onsubmit="return submitOffert(event)">
+        <div class="of-field full">
+          <label for="of-tjanst">Vad gäller det?</label>
+          <select id="of-tjanst" required>
+            <option value="">Välj tjänst</option>
+            <option>Trädgårdsanläggning</option>
+            <option>Gräsmatta &amp; sprinklers</option>
+            <option>Häckplantering eller borttagning</option>
+            <option>Trädgårdsskötsel (löpande)</option>
+            <option>Jordutjämning &amp; markarbete</option>
+            <option>Röjning &amp; bortforsling</option>
+            <option>Annat / vet inte än</option>
+          </select>
+        </div>
+        <div class="of-field">
+          <label for="of-namn">Namn</label>
+          <input id="of-namn" type="text" required autocomplete="name">
+        </div>
+        <div class="of-field">
+          <label for="of-tel">Telefon</label>
+          <input id="of-tel" type="tel" required autocomplete="tel">
+        </div>
+        <div class="of-field full">
+          <label for="of-ort">Ort eller område</label>
+          <input id="of-ort" type="text" required placeholder="T.ex. Bromma, Täby, Nacka">
+        </div>
+        <div class="of-field full">
+          <label for="of-info">Kort om jobbet (valfritt)</label>
+          <textarea id="of-info" placeholder="T.ex. ca 200 kvm gräsmatta, gammal häck ska bort..."></textarea>
+        </div>
+        <button class="cta-button" type="submit">
+          <span>Skicka förfrågan</span>
+          <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        </button>
+        <p class="of-note">Kostnadsfritt och utan förbindelse. Vi ringer eller mejlar inom 24 timmar.</p>
+      </form>
+    </div>
+
+    <div id="of-summary">
+      <div class="m-badge">Nästan klart</div>
+      <h3>Skicka din förfrågan</h3>
+      <p class="m-sub">Här är sammanfattningen. Klicka nedan så öppnas den färdigskriven i din e-post, eller ring oss direkt.</p>
+      <div class="of-sum-box" id="of-sum-text"></div>
+      <div class="of-actions">
+        <a class="cta-button" id="of-mailto" href="#">
+          <span>Öppna i e-post</span>
+          <svg viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        </a>
+        <a class="of-tel" href="tel:+46707666514">Eller ring 070-766 65 14</a>
+      </div>
+    </div>
+
   </div>
 </div>
+
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"LandscapingBusiness",
+  "name":"Bromma Trädgårdsservice",
+  "url":"https://brommatradgardsservice.se/",
+  "telephone":"+46707666514",
+  "email":"jens@brommatradgardsservice.se",
+  "image":"https://brommatradgardsservice.se/logo.svg",
+  "priceRange":"$$",
+  "address":{"@type":"PostalAddress","addressLocality":"Bromma","addressRegion":"Stockholm","addressCountry":"SE"},
+  "areaServed":[
+    {"@type":"City","name":"Bromma"},
+    {"@type":"City","name":"Stockholm"},
+    {"@type":"City","name":"Täby"},
+    {"@type":"City","name":"Lidingö"},
+    {"@type":"City","name":"Nacka"},
+    {"@type":"City","name":"Ekerö"},
+    {"@type":"City","name":"Salem"},
+    {"@type":"City","name":"Solna"},
+    {"@type":"City","name":"Sundbyberg"}
+  ],
+  "hasOfferCatalog":{
+    "@type":"OfferCatalog","name":"Trädgårdstjänster",
+    "itemListElement":[
+      {"@type":"Offer","itemOffered":{"@type":"Service","name":"Trädgårdsanläggning"}},
+      {"@type":"Offer","itemOffered":{"@type":"Service","name":"Gräsmatta och sprinklersystem"}},
+      {"@type":"Offer","itemOffered":{"@type":"Service","name":"Häckplantering och borttagning"}},
+      {"@type":"Offer","itemOffered":{"@type":"Service","name":"Trädgårdsskötsel"}},
+      {"@type":"Offer","itemOffered":{"@type":"Service","name":"Jordutjämning och markarbete"}},
+      {"@type":"Offer","itemOffered":{"@type":"Service","name":"Röjning och bortforsling"}}
+    ]
+  }
+}
+</script>
 
 <script src="https://cdn.jsdelivr.net/npm/lenis@1/dist/lenis.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js"></script>
@@ -408,11 +805,26 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
   "use strict";
   const reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
   const htmlEl=document.documentElement, loaderEl=document.getElementById('loader');
-  function goStatic(){htmlEl.classList.add('fallback');if(loaderEl)loaderEl.classList.add('hidden');if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});}
+
+  function setCountersFinal(){
+    document.querySelectorAll('.stat-number').forEach(el=>{
+      const t=parseFloat(el.dataset.value),d=parseInt(el.dataset.decimals||'0');
+      el.textContent=t.toFixed(d);
+    });
+  }
+  function goStatic(){
+    htmlEl.classList.add('fallback');
+    if(loaderEl)loaderEl.classList.add('hidden');
+    setCountersFinal();
+    if(!reduce)document.querySelectorAll('video').forEach(v=>{try{v.play()}catch(e){}});
+  }
   const failsafe=setTimeout(goStatic,3500);
 
-  // Autoplay-säkring: lågenergiläge på mobil kan blockera autoplay tills första gest
-  function kickVideos(){document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});}
+  // Autoplay-säkring vid första gest (aldrig för reduced-motion)
+  function kickVideos(){
+    if(reduce)return;
+    document.querySelectorAll('video').forEach(v=>{if(v.paused)v.play().catch(()=>{});});
+  }
   addEventListener('touchstart',kickVideos,{once:true,passive:true});
   addEventListener('pointerdown',kickVideos,{once:true,passive:true});
 
@@ -424,9 +836,9 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
   if(typeof gsap==='undefined'){clearTimeout(failsafe);goStatic();return;}
   gsap.registerPlugin(ScrollTrigger);
 
-  // ===== LENIS (valfri — demon funkar utan smooth scroll om CDN:en blockeras) =====
+  // Lenis: syncTouch:false — mobilen scrollar nativt
   if(typeof Lenis!=='undefined'){
-    const lenis=new Lenis({duration:1.15,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:true,touchMultiplier:1.5});
+    const lenis=new Lenis({duration:1.1,easing:t=>1-Math.pow(1-t,3),smoothWheel:true,syncTouch:false});
     lenis.on('scroll',ScrollTrigger.update);
     gsap.ticker.add(t=>lenis.raf(t*1000));
     gsap.ticker.lagSmoothing(0);
@@ -436,24 +848,20 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
   const loaderBar=document.getElementById('loader-bar'),loaderPct=document.getElementById('loader-percent'),loader=document.getElementById('loader');
   let loadProg=0;
   (function simulateLoad(){
-    loadProg+=Math.random()*16+6; if(loadProg>100)loadProg=100;
+    loadProg+=Math.random()*24+16; if(loadProg>100)loadProg=100;
     loaderBar.style.width=loadProg+'%'; loaderPct.textContent=Math.round(loadProg)+'%';
-    if(loadProg<100){setTimeout(simulateLoad,60+Math.random()*90);}
-    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},350);}
+    if(loadProg<100){setTimeout(simulateLoad,35+Math.random()*45);}
+    else{clearTimeout(failsafe);setTimeout(()=>{loader.classList.add('hidden');animateHero();},180);}
   })();
 
-  // ===== HERO-ENTRÉ (ordvis, Élara-stil) =====
   function animateHero(){
     gsap.timeline()
-      .to('.hero-label',{opacity:1,duration:.8,ease:'power2.out'},0.2)
-      .to('.hero-heading .word',{opacity:1,y:0,stagger:.15,duration:1.05,ease:'power3.out'},0.4)
-      .to('.hero-tagline',{opacity:1,duration:.8,ease:'power2.out'},1.05)
-      .to('.hero-scroll-indicator',{opacity:1,duration:.8,ease:'power2.out'},1.35);
+      .to('.hero-label',{opacity:1,duration:.5,ease:'power2.out'},0.05)
+      .to('.hero-heading .word',{opacity:1,y:0,stagger:.08,duration:.55,ease:'power2.out'},0.12)
+      .to('.hero-tagline',{opacity:1,duration:.5,ease:'power2.out'},0.45)
+      .to('.hero-scroll-indicator',{opacity:1,duration:.5,ease:'power2.out'},0.6);
   }
 
-  // ===== CIRKELAVTÄCKNING: videolagret avtäcks MEDAN heron scrollar ut =====
-  // (knutet till heron, inte containern — videon är fullt synlig exakt när heron lämnat,
-  //  inget svart gap mellan hero och första sektionen)
   const scrollContainer=document.getElementById('scroll-container');
   const heroSection=document.querySelector('.hero-standalone');
   const bgWrap=document.getElementById('bgvid-wrap');
@@ -466,7 +874,6 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
     }
   });
 
-  // ===== SEKTIONER (absolut positionerade på progress-fönster, olika entréer) =====
   const sections=document.querySelectorAll('.scroll-section');
   function placeSections(){
     sections.forEach(s=>{
@@ -479,16 +886,15 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
   const sectionStates=new Map();
   sections.forEach(section=>{
     const type=section.dataset.animation,persist=section.dataset.persist==='true';
-    const enter=parseFloat(section.dataset.enter)/100,leave=parseFloat(section.dataset.leave)/100,fadeRange=0.03;
+    const enter=parseFloat(section.dataset.enter)/100,leave=parseFloat(section.dataset.leave)/100,fadeRange=0.045;
     const children=section.querySelectorAll('.section-label,.section-heading,.section-body,.section-note,.cta-button,.cta-sub,.stat,.service-item,.wcard,.projects-head');
     const tl=gsap.timeline({paused:true});
     switch(type){
-      case 'fade-up': tl.from(children,{y:50,opacity:0,stagger:.12,duration:.9,ease:'power3.out'}); break;
-      case 'slide-left': tl.from(children,{x:-80,opacity:0,stagger:.14,duration:.9,ease:'power3.out'}); break;
-      case 'slide-right': tl.from(children,{x:80,opacity:0,stagger:.14,duration:.9,ease:'power3.out'}); break;
-      case 'scale-up': tl.from(children,{scale:.85,opacity:0,stagger:.12,duration:1.0,ease:'power2.out'}); break;
-      case 'stagger-up': tl.from(children,{y:60,opacity:0,stagger:.13,duration:.85,ease:'power3.out'}); break;
-      case 'clip-reveal': tl.from(children,{clipPath:'inset(100% 0 0 0)',opacity:0,stagger:.15,duration:1.2,ease:'power4.inOut'}); break;
+      case 'fade-up': tl.from(children,{y:26,opacity:0,stagger:.06,duration:.45,ease:'power2.out'}); break;
+      case 'slide-left': tl.from(children,{x:-30,opacity:0,stagger:.07,duration:.5,ease:'power2.out'}); break;
+      case 'slide-right': tl.from(children,{x:30,opacity:0,stagger:.07,duration:.5,ease:'power2.out'}); break;
+      case 'scale-up': tl.from(children,{scale:.94,opacity:0,stagger:.06,duration:.5,ease:'power2.out'}); break;
+      case 'stagger-up': tl.from(children,{y:28,opacity:0,stagger:.06,duration:.47,ease:'power2.out'}); break;
     }
     sectionStates.set(section,{tl,persist,enter,leave,fadeRange,active:false,persisted:false});
   });
@@ -501,7 +907,7 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
         const{tl,persist,enter,leave,fadeRange}=state;
         const shouldShow=p>=(enter-fadeRange)&&(persist?true:p<=(leave+fadeRange));
         if(shouldShow&&!state.active){section.classList.add('active');section.style.visibility='visible';tl.play();state.active=true;}
-        else if(!shouldShow&&state.active&&!state.persisted){tl.reverse();state.active=false;}
+        else if(!shouldShow&&state.active&&!state.persisted){state.active=false;}
         if(persist&&state.active)state.persisted=true;
         if(state.active||state.persisted){
           let o=1;
@@ -522,18 +928,18 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
     ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',
       onUpdate:self=>{
         const p=self.progress;
-        if(p>=0.64&&p<=0.78&&!animated.has(el)){
+        if(p>=0.67&&p<=0.80&&!animated.has(el)){
           animated.add(el);
-          gsap.to({val:0},{val:target,duration:2,ease:'power1.out',onUpdate:function(){el.textContent=this.targets()[0].val.toFixed(decimals);}});
-        } else if(p<0.60&&animated.has(el)){animated.delete(el);el.textContent='0';}
+          gsap.to({val:0},{val:target,duration:1.1,ease:'power1.out',onUpdate:function(){el.textContent=this.targets()[0].val.toFixed(decimals);}});
+        } else if(p<0.63&&animated.has(el)){animated.delete(el);el.textContent='0';}
       }
     });
   });
 
-  // ===== DARK OVERLAY (två fönster: projekt + stats) =====
+  // ===== DARK OVERLAY =====
   (function(){
     const overlay=document.getElementById('dark-overlay');
-    const windows=[{e:0.25,l:0.43,max:0.5},{e:0.63,l:0.79,max:0.55}];
+    const windows=[{e:0.27,l:0.46,max:0.5},{e:0.66,l:0.81,max:0.55}];
     const fr=0.035;
     ScrollTrigger.create({trigger:scrollContainer,start:'top top',end:'bottom bottom',scrub:true,
       onUpdate:self=>{
@@ -549,23 +955,63 @@ html.fallback .hero-heading .word{opacity:1!important;transform:none!important}
     });
   })();
 
-  // ===== HEADER + FLYTKNAPP =====
   addEventListener('scroll',()=>{
     document.getElementById('site-header').classList.toggle('scrolled',scrollY>80);
     document.getElementById('float-offert').classList.toggle('visible',scrollY>innerHeight*.6);
   },{passive:true});
 
-  // ===== RESIZE =====
   addEventListener('resize',()=>{placeSections();ScrollTrigger.refresh();});
-
   setTimeout(()=>ScrollTrigger.refresh(),400);
 })();
 
-// ===== MODAL =====
-function openModal(){document.getElementById('modal').classList.add('open');document.body.style.overflow='hidden';}
-function closeModal(){document.getElementById('modal').classList.remove('open');document.body.style.overflow='';}
-document.getElementById('modal').addEventListener('click',function(e){if(e.target===this)closeModal();});
-document.addEventListener('keydown',e=>{if(e.key==='Escape')closeModal();});
+// ===== OFFERTMODAL =====
+function openOffert(){
+  document.getElementById('offert-modal').classList.add('open');
+  document.body.style.overflow='hidden';
+}
+function closeOffert(){
+  document.getElementById('offert-modal').classList.remove('open');
+  document.body.style.overflow='';
+  document.getElementById('of-step1').style.display='';
+  document.getElementById('of-summary').classList.remove('show');
+}
+document.getElementById('offert-modal').addEventListener('click',function(e){if(e.target===this)closeOffert();});
+document.addEventListener('keydown',e=>{if(e.key==='Escape')closeOffert();});
+
+function submitOffert(e){
+  e.preventDefault();
+  const tjanst=document.getElementById('of-tjanst').value;
+  const namn=document.getElementById('of-namn').value.trim();
+  const tel=document.getElementById('of-tel').value.trim();
+  const ort=document.getElementById('of-ort').value.trim();
+  const info=document.getElementById('of-info').value.trim();
+
+  const rows=[
+    '<b>Tjänst:</b> '+tjanst,
+    '<b>Namn:</b> '+namn,
+    '<b>Telefon:</b> '+tel,
+    '<b>Ort:</b> '+ort
+  ];
+  if(info)rows.push('<b>Om jobbet:</b> '+info);
+  document.getElementById('of-sum-text').innerHTML=rows.join('<br>');
+
+  const body=
+    'Hej!\n\nJag vill gärna ha en offert.\n\n'+
+    'Tjänst: '+tjanst+'\n'+
+    'Namn: '+namn+'\n'+
+    'Telefon: '+tel+'\n'+
+    'Ort: '+ort+'\n'+
+    (info?('Om jobbet: '+info+'\n'):'')+
+    '\nVänliga hälsningar\n'+namn;
+  document.getElementById('of-mailto').href=
+    'mailto:jens@brommatradgardsservice.se'+
+    '?subject='+encodeURIComponent('Offertförfrågan: '+tjanst+' ('+ort+')')+
+    '&body='+encodeURIComponent(body);
+
+  document.getElementById('of-step1').style.display='none';
+  document.getElementById('of-summary').classList.add('show');
+  return false;
+}
 
 // ===== MOBILNAV =====
 function toggleMobileNav(){
@@ -578,12 +1024,6 @@ function closeMobileNav(){
   document.getElementById('hamburger').classList.remove('open');
   document.body.style.overflow='';
 }
-</script>
-<!-- Cal.eu embed -->
-<script type="text/javascript">
-(function(C,A,L){let p=function(a,ar){a.q.push(ar)};let d=C.document;C.Cal=C.Cal||function(){let cal=C.Cal;let ar=arguments;if(!cal.loaded){cal.ns={};cal.q=cal.q||[];d.head.appendChild(d.createElement("script")).src=A;cal.loaded=true}if(ar[0]===L){const api=function(){p(api,arguments)};const namespace=ar[1];api.q=api.q||[];if(typeof namespace==="string"){cal.ns[namespace]=cal.ns[namespace]||api;p(cal.ns[namespace],ar);p(cal,[L,namespace,...Array.from(ar).slice(2)])}else p(cal,ar);return}p(cal,ar)};})(window,"https://cal.eu/embed/embed.js","init");
-Cal("init","15min",{origin:"https://cal.eu"});
-Cal.ns["15min"]("ui",{"hideEventTypeDetails":false,"layout":"month_view"});
 </script>
 </body>
 </html>

--- a/bahkobyra/cloud/brommatradgardsservice/logo.svg
+++ b/bahkobyra/cloud/brommatradgardsservice/logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 112" role="img" aria-label="Bromma Trädgårdsservice">
+  <title>Bromma Trädgårdsservice</title>
+  <defs>
+    <linearGradient id="leaf" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#9FE08A"/>
+      <stop offset="55%" stop-color="#6BBF59"/>
+      <stop offset="100%" stop-color="#2E7D32"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Trädmärke -->
+  <g transform="translate(48,56)">
+    <circle r="45" fill="none" stroke="url(#leaf)" stroke-width="2.6" opacity=".5"/>
+    <path d="M0,-30 C14,-30 25,-19 25,-6 C25,5 15,13 0,13 C-15,13 -25,5 -25,-6 C-25,-19 -14,-30 0,-30 Z"
+          fill="url(#leaf)"/>
+    <path d="M0,-26 L0,12 M0,-14 L-11,-5 M0,-14 L11,-5 M0,-1 L-9,7 M0,-1 L9,7"
+          stroke="#0B0B0D" stroke-width="2" stroke-linecap="round" opacity=".38" fill="none"/>
+    <path d="M0,13 L0,30" stroke="url(#leaf)" stroke-width="4.5" stroke-linecap="round"/>
+    <path d="M-16,32 L16,32" stroke="url(#leaf)" stroke-width="2.6" stroke-linecap="round" opacity=".7"/>
+  </g>
+
+  <!-- Ordmärke -->
+  <text x="112" y="54" font-family="Archivo, system-ui, sans-serif" font-weight="900"
+        font-size="45" letter-spacing="0.5" fill="#F2EFE9">BROMMA</text>
+  <text x="114" y="87" font-family="Archivo, system-ui, sans-serif" font-weight="600"
+        font-size="18.5" letter-spacing="5.1" fill="#6BBF59">TRÄDGÅRDSSERVICE</text>
+</svg>


### PR DESCRIPTION
Bygger ut demon till levererad hemsida för betalande kund.

**Buggfix:** hero- och bakgrundsvideon har aldrig laddat, båda `src`-attributen hade cloudfront-domänen dubblerad så bara postern visades. Rättat.

**Innehåll**
- Riktiga kontaktuppgifter: 070-766 65 14, jens@brommatradgardsservice.se
- Sex verkliga kundomdömen (namn, jobb, ort, datum)
- Tjänster och områden hämtade ur omdömena: anläggning, gräsmatta/sprinklers, häckplantering, skötsel, jordutjämning, bortforsling · Bromma, Täby, Lidingö, Nacka, Ekerö, Salem m.fl.
- Statisk del: tjänster, omdömen, om oss, områden, process, galleri, kontakt
- Offertformulär med sammanfattning och förifylld mailto
- LocalBusiness-schema, canonical, OG-taggar, `noindex` borttagen
- Egen logotyp (SVG, skalbar, används även som favicon)

**Tempo** enligt scroll-cinematic-skillen: 520vh/620vh, `syncTouch:false`, ingen reverse vid utscroll, `fadeRange .045`, kortare entréer, räknarna visar rätt slutvärde i reduced-motion.

**Video återanvänd** från befintlig demo, 0 Higgsfield-credits.

**QA:** `node --check` OK, JSON-LD validerar, inga dubblerade URL:er eller platshållare kvar, sektionsfönster överlappar inte, ögongranskad i 1440×900 och 390×844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeWKdtDPBWMzgCejUg4CD4)_